### PR TITLE
First attempt to add waterway lines (fix #81)

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -26,5 +26,6 @@ UPDATE planet_osm_line AS line SET
     WHERE line.osm_id = road.osm_id;
 
 PERFORM mz_create_partial_index_if_not_exists('planet_osm_line_mz_road_level_index', 'planet_osm_line', 'mz_road_level', 'mz_road_level IS NOT NULL');
+PERFORM mz_create_partial_index_if_not_exists('planet_osm_line_waterway', 'planet_osm_line', 'waterway', 'waterway IS NOT NULL');
 
 END $$;

--- a/queries/water-z11.pgsql
+++ b/queries/water-z11.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 25600 -- 4px
         AND mz_way12 && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'river')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z12.pgsql
+++ b/queries/water-z12.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 6400 -- 4px
         AND mz_way12 && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'river')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z13.pgsql
+++ b/queries/water-z13.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 1600 -- 4px
         AND way && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'dam', 'river', 'stream')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z14.pgsql
+++ b/queries/water-z14.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 400 -- 4px
         AND way && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'dam', 'river', 'stream')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z15.pgsql
+++ b/queries/water-z15.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 100 -- 4px
         AND way && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'dam', 'river', 'stream')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z16.pgsql
+++ b/queries/water-z16.pgsql
@@ -41,7 +41,7 @@ FROM
 
     SELECT name,
            NULL AS area,
-           COALESCE("waterway", "natural", "landuse") AS kind,
+           waterway AS kind,
            'openstreetmap.org' AS source,
            way AS __geometry__,
            mz_id AS __id__

--- a/queries/water-z16.pgsql
+++ b/queries/water-z16.pgsql
@@ -34,6 +34,24 @@ FROM
         mz_is_water = TRUE
         AND way && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           COALESCE("waterway", "natural", "landuse") AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'dam', 'ditch', 'drain', 'river', 'stream')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/queries/water-z9.pgsql
+++ b/queries/water-z9.pgsql
@@ -35,6 +35,24 @@ FROM
         AND way_area::bigint > 102400 -- 4px
         AND mz_way12 && !bbox!
 
+    --
+    -- Water line geometries
+    --
+    UNION
+
+    SELECT name,
+           NULL AS area,
+           waterway AS kind,
+           'openstreetmap.org' AS source,
+           way AS __geometry__,
+           mz_id AS __id__
+
+    FROM planet_osm_line
+
+    WHERE
+        waterway IN ('canal', 'river')
+        AND way && !bbox!
+
 ) AS water_areas
 
 ORDER BY

--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -254,7 +254,7 @@
                 "queries/water-z16.pgsql"
               ],
               "suppress_simplification": [12],
-              "geometry_types": ["Polygon", "MultiPolygon"]
+              "geometry_types": ["Polygon", "MultiPolygon", "LineString", "MultiLineString"]
             }
           }
         }


### PR DESCRIPTION
So here is a shot :)

`river` and `canal` are made visible starting at zoom 9, `dam` and `stream` starting at zoom 13 and `ditch` and `drain` at zoom 16.

I'm not sure if we need a dedicated index, maybe a btree on waterway plus way. I'm happy to have your feedback on this :)

Thanks for reviewing!

Yohan

Ref: #81 