### PR TITLE
Support more places

### DIFF
--- a/queries/places-z12.pgsql
+++ b/queries/places-z12.pgsql
@@ -11,11 +11,16 @@ WHERE name IS NOT NULL
 AND place IN (
 	'city',
 	'county',
-	'province',
+    'province',
+	'island',
 	'town',
-	'neighbourhood',
+    'neighbourhood',
+	'suburb',
 	'locality',
-	'lake'
+	'lake',
+    'village',
+    'hamlet',
+    'isolated_dwelling'
 )
 
 ORDER BY __id__ ASC

--- a/queries/places-z9.pgsql
+++ b/queries/places-z9.pgsql
@@ -13,7 +13,8 @@ AND place IN (
 	'city',
 	'district',
 	'county',
-	'province'
+	'province',
+    'island'
 )
 
 ORDER BY __id__ ASC


### PR DESCRIPTION
Adds `island` starting at zoom 9, and `village`, `suburb`, `hamlet` and `isolated_dwelling` starting at 12.

(Not sure about the space/tab usage, I see both in the query files.)

Thanks!

Yohan