### PR TITLE
install mapbox_vector_tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sudo apt-get install -y libmapnik mapnik-utils python-mapnik
 
 sudo pip install shapely
 sudo pip install protobuf
-
+sudo pip install mapbox_vector_tile
 
 ```
 


### PR DESCRIPTION
fix miss mapbox_vector_tile
```
tilestache-server.py -c ../vector-datasource/tilestache.cfg 
Error loading Tilestache config:
Traceback (most recent call last):
  File "/usr/local/bin/tilestache-server.py", line 55, in <module>
    app = TileStache.WSGITileServer(config=options.file, autoreload=True)
  File "/usr/local/lib/python2.7/dist-packages/TileStache/__init__.py", line 400, in __init__
    self.config = parseConfigfile(config)
  File "/usr/local/lib/python2.7/dist-packages/TileStache/__init__.py", line 116, in parseConfigfile
    return Config.buildConfiguration(config_dict, dirpath)
  File "/usr/local/lib/python2.7/dist-packages/TileStache/Config.py", line 221, in buildConfiguration
    config.layers[name] = _parseConfigfileLayer(layer_dict, config, dirpath)
  File "/usr/local/lib/python2.7/dist-packages/TileStache/Config.py", line 441, in _parseConfigfileLayer
    _class = loadClassPath(provider_dict['class'])
  File "/usr/local/lib/python2.7/dist-packages/TileStache/Config.py", line 481, in loadClassPath
    raise Core.KnownUnknown('Tried to import %s, but: %s' % (classpath, e))
TileStache.Core.KnownUnknown: Tried to import TileStache.Goodies.VecTiles:MultiProvider, but: No module named mapbox_vector_tile
```