### PR TITLE
Landuse labels layer

### DIFF
--- a/queries/landuse-labels-z10.pgsql
+++ b/queries/landuse-labels-z10.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 102400 -- 4px

--- a/queries/landuse-labels-z11.pgsql
+++ b/queries/landuse-labels-z11.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 25600 -- 4px

--- a/queries/landuse-labels-z12.pgsql
+++ b/queries/landuse-labels-z12.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 6400 -- 4px

--- a/queries/landuse-labels-z13.pgsql
+++ b/queries/landuse-labels-z13.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 1600 -- 4px

--- a/queries/landuse-labels-z14.pgsql
+++ b/queries/landuse-labels-z14.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 400 -- 4px

--- a/queries/landuse-labels-z15.pgsql
+++ b/queries/landuse-labels-z15.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 100 -- 4px

--- a/queries/landuse-labels-z16.pgsql
+++ b/queries/landuse-labels-z16.pgsql
@@ -1,0 +1,12 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE

--- a/queries/landuse-labels-z4.pgsql
+++ b/queries/landuse-labels-z4.pgsql
@@ -1,0 +1,13 @@
+--
+-- Urban Areas
+--
+
+SELECT
+    '' AS name,
+    way_area::bigint AS area,
+    'urban area' AS kind,
+    'naturalearthdata.com' AS source,
+    ST_Centroid(the_geom) AS __geometry__,
+    gid AS __id__
+
+FROM ne_50m_urban_areas

--- a/queries/landuse-labels-z6.pgsql
+++ b/queries/landuse-labels-z6.pgsql
@@ -1,0 +1,37 @@
+SELECT name, area, kind, source, __geometry__, __id__
+
+FROM
+(
+    --
+    -- Urban Areas
+    --
+    SELECT
+        '' AS name,
+        way_area::bigint AS area,
+        'urban area' AS kind,
+        'naturalearthdata.com' AS source,
+        ST_Centroid(the_geom) AS __geometry__,
+        gid AS __id__
+
+    FROM ne_10m_urban_areas
+
+    WHERE the_geom && !bbox!
+
+    --
+    -- Parks and Protected Lands
+    --
+    UNION
+
+    SELECT
+        name,
+        way_area::bigint AS area,
+        'park or protected land' AS kind,
+        'naturalearthdata.com' AS source,
+        ST_Centroid(the_geom) AS __geometry__,
+        gid AS __id__
+
+    FROM ne_10m_parks_and_protected_lands
+
+    WHERE the_geom && !bbox!
+
+) AS land_usages

--- a/queries/landuse-labels-z9.pgsql
+++ b/queries/landuse-labels-z9.pgsql
@@ -1,0 +1,13 @@
+SELECT
+    name,
+    way_area::bigint AS area,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity") AS kind,
+    'openstreetmap.org' AS source,
+    ST_Centroid(way) AS __geometry__,
+    osm_id AS __id__
+
+FROM planet_osm_polygon
+
+WHERE
+    mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway") = TRUE
+    AND way_area::bigint > 409600 -- 4px

--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -258,7 +258,9 @@
               ],
               "geometry_types": ["Point", "MultiPoint"],
               "transform_fns": [
-                "TileStache.Goodies.VecTiles.transform.normalize_osm_id"
+                "TileStache.Goodies.VecTiles.transform.add_id_to_properties",
+                "TileStache.Goodies.VecTiles.transform.detect_osm_relation",
+                "TileStache.Goodies.VecTiles.transform.remove_feature_id"
               ],
               "sort_fn": "TileStache.Goodies.VecTiles.sort.landuse"
             }

--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -17,6 +17,7 @@
                 "earth",
                 "places",
                 "landuse",
+                "landuse_labels",
                 "roads",
                 "buildings",
                 "pois"
@@ -210,6 +211,41 @@
                 "queries/landuse-z16.pgsql"
               ],
               "geometry_types": ["Polygon", "MultiPolygon"],
+              "transform_fns": [
+                "TileStache.Goodies.VecTiles.transform.normalize_osm_id"
+              ],
+              "sort_fn": "TileStache.Goodies.VecTiles.sort.landuse"
+            }
+          }
+        },
+        "landuse_labels": {
+          "allowed origin": "*",
+          "provider": {
+            "class": "TileStache.Goodies.VecTiles:Provider",
+            "kwargs": {
+              "dbinfo": {
+                "host": "localhost",
+                "port": 5432,
+                "user": "osm",
+                "database": "osm"
+              },
+              "queries": [
+                null, null, null, null,
+                "queries/landuse-labels-z4.pgsql",
+                "queries/landuse-labels-z4.pgsql",
+                "queries/landuse-labels-z6.pgsql",
+                "queries/landuse-labels-z6.pgsql",
+                "queries/landuse-labels-z6.pgsql",
+                "queries/landuse-labels-z9.pgsql",
+                "queries/landuse-labels-z10.pgsql",
+                "queries/landuse-labels-z11.pgsql",
+                "queries/landuse-labels-z12.pgsql",
+                "queries/landuse-labels-z13.pgsql",
+                "queries/landuse-labels-z14.pgsql",
+                "queries/landuse-labels-z15.pgsql",
+                "queries/landuse-labels-z16.pgsql"
+              ],
+              "geometry_types": ["Point", "MultiPoint"],
               "transform_fns": [
                 "TileStache.Goodies.VecTiles.transform.normalize_osm_id"
               ],


### PR DESCRIPTION
Add a layer for simple landuse labels, using the same landuse queries but returning centroids instead of complete polygons.