### PR TITLE
fix tiles' internal seams by unifying geometries

### DIFF
--- a/queries/earth-z0.pgsql
+++ b/queries/earth-z0.pgsql
@@ -1,6 +1,8 @@
 SELECT
     'base' AS land,
-    the_geom AS __geometry__,
-    gid AS __id__
+    st_union(the_geom) AS __geometry__,
+    max(gid) AS __id__
 FROM
     ne_110m_land
+WHERE
+    the_geom && !bbox!

--- a/queries/earth-z4.pgsql
+++ b/queries/earth-z4.pgsql
@@ -1,6 +1,8 @@
 SELECT
     'base' AS land,
-    the_geom AS __geometry__,
-    gid AS __id__
+    st_union(the_geom) AS __geometry__,
+    max(gid) AS __id__
 FROM
     ne_50m_land
+WHERE
+    the_geom && !bbox!

--- a/queries/earth-z7.pgsql
+++ b/queries/earth-z7.pgsql
@@ -1,6 +1,8 @@
 SELECT
     'base' AS land,
-    the_geom AS __geometry__,
-    gid AS __id__
+    st_union(the_geom) AS __geometry__,
+    max(gid) AS __id__
 FROM
     ne_10m_land
+WHERE
+    the_geom && !bbox!

--- a/queries/earth-z9.pgsql
+++ b/queries/earth-z9.pgsql
@@ -1,6 +1,8 @@
 SELECT
     'base' AS land,
-    the_geom AS __geometry__,
-    gid AS __id__
+    st_union(the_geom) AS __geometry__,
+    max(gid) AS __id__
 FROM
     land_polygons
+WHERE
+    the_geom && !bbox!

--- a/queries/water-z0.pgsql
+++ b/queries/water-z0.pgsql
@@ -7,11 +7,11 @@ FROM
     --
     SELECT
         '' AS name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'ocean' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_110m_ocean
 
@@ -24,14 +24,15 @@ FROM
 
     SELECT
         name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'lake' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_110m_lakes
 
     WHERE the_geom && !bbox!
+    GROUP BY name
 
 ) AS water_areas

--- a/queries/water-z4.pgsql
+++ b/queries/water-z4.pgsql
@@ -7,11 +7,11 @@ FROM
     --
     SELECT
         '' AS name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'ocean' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_50m_ocean
 
@@ -24,15 +24,16 @@ FROM
 
     SELECT
         name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'lake' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_50m_lakes
 
     WHERE the_geom && !bbox!
+    GROUP BY name
 
     --
     -- Playas
@@ -41,14 +42,15 @@ FROM
 
     SELECT
         name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'playa' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_50m_playas
 
     WHERE the_geom && !bbox!
+    GROUP BY name
 
 ) AS water_areas

--- a/queries/water-z7.pgsql
+++ b/queries/water-z7.pgsql
@@ -7,11 +7,11 @@ FROM
     --
     SELECT
         '' AS name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'ocean' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_10m_ocean
 
@@ -24,15 +24,16 @@ FROM
 
     SELECT
         name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'lake' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_10m_lakes
 
     WHERE the_geom && !bbox!
+    GROUP BY name
 
     --
     -- Playas
@@ -41,14 +42,15 @@ FROM
 
     SELECT
         name,
-        way_area::bigint AS area,
+        sum(way_area)::bigint AS area,
         'playa' AS kind,
         'naturalearthdata.com' AS source,
-        the_geom AS __geometry__,
-        gid AS __id__
+        st_union(the_geom) AS __geometry__,
+        max(gid) __id__
 
     FROM ne_10m_playas
 
     WHERE the_geom && !bbox!
+    GROUP BY name
 
 ) AS water_areas


### PR DESCRIPTION
`st_union()` the Natural Earth geometries in all `earth` queries, and `water` queries only for zoom levels 0, 4, and 7. This should resolve the issue of tiles' "internal" seams, which are caused when a continuous earth/water feature is composed of multiple different polygons at the data level, which, when simplified, slightly diverge away from one another and create a gap. By creating a union of the polygons, we can ensure that simplification will only alter the exterior of that feature.