### PR TITLE
Set simplify_before_intersect=true for earth/water.

### DIFF
--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -295,6 +295,7 @@
                 "TileStache.Goodies.VecTiles.transform.detect_osm_relation",
                 "TileStache.Goodies.VecTiles.transform.remove_feature_id"
               ],
+              "simplify_before_intersect": true,
               "sort_fn": "TileStache.Goodies.VecTiles.sort.earth"
             }
           }
@@ -335,6 +336,7 @@
                 "TileStache.Goodies.VecTiles.transform.detect_osm_relation",
                 "TileStache.Goodies.VecTiles.transform.remove_feature_id"
               ],
+              "simplify_before_intersect": true,
               "sort_fn": "TileStache.Goodies.VecTiles.sort.water"
             }
           }


### PR DESCRIPTION
This is necessary for the code-changes that fix tile seams in mapzen/TileStache#34 and mapzen/tilequeue#16 to kick in.