### PR TITLE
add add-external-data script to data folder to pull in polygons

### DIFF
--- a/data/add-external-data.sh
+++ b/data/add-external-data.sh
@@ -1,0 +1,21 @@
+# water polygons
+#
+wget http://data.openstreetmapdata.com/water-polygons-split-3857.zip
+unzip water-polygons-split-3857.zip
+shp2pgsql -dID -s 900913 -W Windows-1252 -g the_geom water-polygons-split-3857/water_polygons.shp water_polygons | psql "$@" 
+rm ./water-polygons-split-3857.zip && rm -rf ./water-polygons-split-3857
+
+# land polygons
+#
+wget http://data.openstreetmapdata.com/land-polygons-split-3857.zip
+unzip land-polygons-split-3857.zip
+shp2pgsql -dID -s 900913 -W Windows-1252 -g the_geom land-polygons-split-3857/land_polygons.shp land_polygons | psql "$@"
+rm ./land-polygons-split-3857.zip && rm -rf ./land-polygons-split-3857
+
+# simplified land polygons
+#
+wget http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip
+unzip simplified-land-polygons-complete-3857.zip
+shp2pgsql -dID -s 900913 -W Windows-1252 -g the_geom simplified-land-polygons-complete-3857/simplified_land_polygons.shp simplified_land_polygons | psql "$@"
+rm ./simplified-land-polygons-complete-3857.zip && rm -rf ./simplified-land-polygons-complete-3857
+


### PR DESCRIPTION
Internal data script to help prepare the database instead of having to download a gist as it currently describes in the wiki. mapzen/vector-datasource#108