### PR TITLE
Project the network tag from the relation.

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -7,7 +7,7 @@ BEGIN
 
 CREATE INDEX planet_osm_line_waterway_index ON planet_osm_line(waterway) WHERE waterway IS NOT NULL;
 CREATE INDEX planet_osm_line_admin_boundaries_index ON planet_osm_line(boundary) WHERE boundary='administrative';
-CREATE INDEX planet_osm_line_road_level_index ON planet_osm_line(mz_calculate_road_level(highway, railway, aeroway, tags->'network')) WHERE mz_calculate_road_level(highway, railway, aeroway, tags->'network') IS NOT NULL;
+CREATE INDEX planet_osm_line_road_level_index ON planet_osm_line(mz_calculate_road_level(highway, railway, aeroway)) WHERE mz_calculate_road_level(highway, railway, aeroway) IS NOT NULL;
 CREATE INDEX planet_osm_line_transit_level_index ON planet_osm_line(mz_calculate_transit_level(route)) WHERE mz_calculate_transit_level(route) IS NOT NULL;
 
 END $$;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -112,7 +112,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
-        CASE WHEN (highway_val IN ('motorway', 'trunk', 'primary', 'motorway_link') OR network_val='US:I') THEN 9
+        CASE WHEN highway_val IN ('motorway', 'trunk', 'primary', 'motorway_link') THEN 9
              WHEN highway_val IN ('secondary') THEN 10
              WHEN (highway_val IN ('tertiary')
                 OR aeroway_val IN ('runway', 'taxiway')) THEN 11

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -108,7 +108,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text, network_val text)
+CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text)
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -157,3 +157,72 @@ BEGIN
     );
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- mz_rel_get_tag returns the tag value associated with a given
+-- key, or NULL if the tag is not set in the array.
+--
+-- tags in the planet_osm_rels table are stored in a flat array
+-- rather than in an hstore variable. so this function makes it
+-- easier to extract values from that array as if it were
+-- associative.
+--
+CREATE OR REPLACE FUNCTION mz_rel_get_tag(
+  tags text[],
+  k text)
+RETURNS text AS $$
+DECLARE
+  lo CONSTANT integer := array_lower(tags, 1);
+  hi CONSTANT integer := array_upper(tags, 1);
+BEGIN
+  -- tags is an array of key-value pairs inline, so to get the
+  -- keys only we want each odd offset.
+  FOR i IN 0 .. ((hi - lo - 1) / 2)
+  LOOP
+    IF tags[2 * i + lo] = k THEN
+      RETURN tags[2 * i + lo + 1];
+    END IF;
+  END LOOP;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- mz_first_dedup returns the lexicographically first non-NULL
+-- entry in an array of text.
+--
+-- this is used to get a single value from the array of perhaps
+-- many relations that a way can be a member of. we're not
+-- interested in NULL values, so those can be discarded. it
+-- remains to be seen if lexicographic ordering is any good for
+-- network names, but in the limited testing i've done so far,
+-- it seems to do okay.
+--
+CREATE OR REPLACE FUNCTION mz_first_dedup(
+  arr text[])
+RETURNS text AS $$
+DECLARE
+  rv text;
+BEGIN
+  SELECT DISTINCT y.x INTO rv FROM (SELECT unnest(arr) as x) y
+    WHERE y.x IS NOT NULL LIMIT 1;
+  RETURN rv;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- mz_get_rel_network returns a network tag, or NULL, for a
+-- given way ID.
+--
+-- it does this by joining onto the relations slim table, so it
+-- won't work if you dropped the slim tables, or didn't use slim
+-- mode in osm2pgsql.
+--
+CREATE OR REPLACE FUNCTION mz_get_rel_network(
+  way_id bigint)
+RETURNS text AS $$
+BEGIN
+  RETURN mz_first_dedup(ARRAY(
+    SELECT mz_rel_get_tag(tags, 'network')
+    FROM planet_osm_rels
+    WHERE parts && ARRAY[way_id]
+      AND parts[way_off+1:rel_off] && ARRAY[way_id]));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -37,7 +37,13 @@ SELECT
     route,
     tags->'type' AS type,
     tags->'colour' AS colour,
-    tags->'network' AS network,
+    CASE WHEN highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link',
+                          'primary', 'primary_link', 'secondary', 'secondary_link',
+                          'tertiary', 'tertiary_link')
+              OR railway IN ('rail', 'tram', 'light_rail', 'narrow_gauge', 'monorail')
+              THEN mz_get_rel_network(osm_id)
+         ELSE tags->'network'
+         END AS network,
     tags->'state' AS state,
     tags->'symbol' AS symbol,
     tags->'description' AS description,
@@ -53,5 +59,9 @@ FROM planet_osm_line
 WHERE
     {{ bounds|bbox_filter('way') }}
     AND mz_calculate_road_level(highway, railway, aeroway, tags->'network') <= {{ zoom }}
+    -- the below is to filter out any relations-as-roads, since instead we are
+    -- projecting the network attribute onto the ways. it might need some finessing
+    -- if we're rendering other stuff from relations like cycle routes.
+    AND osm_id > 0
 
 {% endif %}

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -58,7 +58,7 @@ FROM planet_osm_line
 
 WHERE
     {{ bounds|bbox_filter('way') }}
-    AND mz_calculate_road_level(highway, railway, aeroway, tags->'network') <= {{ zoom }}
+    AND mz_calculate_road_level(highway, railway, aeroway) <= {{ zoom }}
     -- the below is to filter out any relations-as-roads, since instead we are
     -- projecting the network attribute onto the ways. it might need some finessing
     -- if we're rendering other stuff from relations like cycle routes.


### PR DESCRIPTION
Project the network tag, for some classes of roads, from the relations which contain them. Also, don't return relation geometry. This should mean that the ways get all the relevant network information, and also keep the per-way information like brunnel status.