### PR TITLE
Add explicit, calculated default for scalerank.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -43,6 +43,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
       - TileStache.Goodies.VecTiles.transform.tags_remove
       - TileStache.Goodies.VecTiles.transform.place_ne_capital
+      - TileStache.Goodies.VecTiles.transform.calculate_default_place_scalerank
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
       - TileStache.Goodies.VecTiles.transform.remove_feature_id


### PR DESCRIPTION
On features which don't already have a curated scalerank, use the place kind to calculate a default scalerank and add that as a property.

Requires mapzen/TileStache#41.