### PR TITLE
Add config to enable intercut of landuse and roads.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -147,3 +147,9 @@ layers:
       - TileStache.Goodies.VecTiles.transform.route_name
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
     sort: TileStache.Goodies.VecTiles.sort.transit
+post_process:
+  TileStache.Goodies.VecTiles.transform.intercut:
+    base_layer: roads
+    cutting_layer: landuse
+    attribute: kind
+    target_attribute: landuse_kind


### PR DESCRIPTION
This will enable the code, already merged, for intercut and apply the landuse polygon's kind tag as "landuse_kind" on the roads. The roads will be split at landuse polygon boundaries.

Refs #136.

I almost forgot about this in the confusion. Just the config update to enable intercutting.