### PR TITLE
Handle the case where tags is NULL.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -174,6 +174,11 @@ DECLARE
   lo CONSTANT integer := array_lower(tags, 1);
   hi CONSTANT integer := array_upper(tags, 1);
 BEGIN
+  -- if tags is null, then we're not going to find any values
+  -- in it, so just short-circuit and return NULL.
+  IF tags IS NULL THEN
+    RETURN NULL;
+  END IF;
   -- tags is an array of key-value pairs inline, so to get the
   -- keys only we want each odd offset.
   FOR i IN 0 .. ((hi - lo - 1) / 2)


### PR DESCRIPTION
Ooops. Should have handled this the first time around, but didn't check whether `tags` was NULLable. Turns out it is, at least on my osm2pgsql database, so `mz_rel_get_tag()` needs to not explode when it encounters one.

@rmarianski could you review, please?