### PR TITLE
Add power polygons to landuse and landuse labels layers.

### DIFF
--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -20,7 +20,7 @@ ALTER TABLE planet_osm_polygon ADD COLUMN mz_centroid GEOMETRY;
 UPDATE planet_osm_polygon SET
     mz_is_landuse = TRUE,
     mz_centroid = ST_Centroid(way)
-    WHERE mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made") = TRUE;
+    WHERE mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power") = TRUE;
 
 CREATE INDEX planet_osm_polygon_is_landuse_col_index ON planet_osm_polygon(mz_is_landuse) WHERE mz_is_landuse=TRUE;
 CREATE INDEX planet_osm_polygon_centroid_landuse_index ON planet_osm_polygon USING gist(mz_centroid) WHERE mz_is_landuse=TRUE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE FUNCTION mz_calculate_is_landuse(
     landuse_val text, leisure_val text, natural_val text, highway_val text,
-    amenity_val text, aeroway_val text, tourism_val text, man_made_val text)
+    amenity_val text, aeroway_val text, tourism_val text, man_made_val text,
+    power_val text)
 RETURNS BOOLEAN AS $$
 BEGIN
     RETURN
@@ -18,7 +19,8 @@ BEGIN
      OR aeroway_val IN ('runway', 'taxiway', 'apron', 'aerodrome')
      OR tourism_val IN ('zoo')
      OR man_made_val IN ('pier', 'wastewater_plant', 'works', 'bridge', 'tower',
-                         'breakwater', 'water_works', 'groyne', 'dike', 'cutline');
+                         'breakwater', 'water_works', 'groyne', 'dike', 'cutline')
+     OR power_val IN   ('plant', 'generator', 'substation', 'station', 'sub_station');
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION mz_trigger_function_landuse()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made") then
+    IF mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power") then
         NEW.mz_is_landuse := TRUE;
         NEW.mz_centroid := ST_Centroid(NEW.way);
     ELSE

--- a/queries.yaml
+++ b/queries.yaml
@@ -58,6 +58,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
       - TileStache.Goodies.VecTiles.transform.tags_remove
+      - TileStache.Goodies.VecTiles.transform.remap_deprecated_landuse_kinds
       - TileStache.Goodies.VecTiles.transform.landuse_sort_key
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
@@ -71,6 +72,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
       - TileStache.Goodies.VecTiles.transform.tags_remove
+      - TileStache.Goodies.VecTiles.transform.remap_deprecated_landuse_kinds
       - TileStache.Goodies.VecTiles.transform.landuse_sort_key
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -41,7 +41,7 @@ WHERE
 SELECT
     name,
     way_area::bigint AS area,
-    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made") AS kind,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
     osm_id AS __id__,

--- a/queries/landuse_labels.jinja2
+++ b/queries/landuse_labels.jinja2
@@ -1,7 +1,7 @@
 SELECT
     name,
     way_area::bigint AS area,
-    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made") AS kind,
+    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}mz_centroid{% endfilter %} AS __geometry__,
     osm_id AS __id__,


### PR DESCRIPTION
Refs #186.

This'll require re-running the bit from `apply-planet_osm_polygon.sql` where it updates `mz_is_landuse` after loading the new functions.

@rmarianski could you review, please?
