### PR TITLE
Add sorting to landuse intercut.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -167,3 +167,9 @@ post_process:
       id: true
       source: true
       boundary: "yes"
+  TileStache.Goodies.VecTiles.transform.overlap:
+    base_layer: buildings
+    cutting_layer: landuse
+    attribute: kind
+    target_attribute: landuse_kind
+    cutting_attrs: { sort_key: 'order', reverse: True }

--- a/queries.yaml
+++ b/queries.yaml
@@ -159,6 +159,7 @@ post_process:
     cutting_layer: landuse
     attribute: kind
     target_attribute: landuse_kind
+    cutting_attrs: { sort_key: 'order', reverse: True }
   TileStache.Goodies.VecTiles.transform.exterior_boundaries:
     base_layer: water
     prop_transform:


### PR DESCRIPTION
Refs #198.

Also adds missing config from #142, also updated to do the sorting based on the existing `order` parameter.

@rmarianski could you review, please?