### PR TITLE
Boundary left / right names

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -233,3 +233,18 @@ BEGIN
       AND parts[way_off+1:rel_off] && ARRAY[way_id]));
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- adds the prefix onto every key in an hstore value
+CREATE OR REPLACE FUNCTION mz_hstore_add_prefix(
+  tags hstore,
+  prefix text)
+RETURNS hstore AS $$
+DECLARE
+  new_tags hstore;
+BEGIN
+  SELECT hstore(array_agg(prefix || key), array_agg(value))
+    INTO STRICT new_tags
+    FROM each(tags);
+  RETURN new_tags;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -57,16 +57,37 @@ WHERE
 
 {% else %}
 
+WITH admin_polygons AS (
+  SELECT *
+  FROM planet_osm_polygon
+  WHERE
+    {{ bounds|bbox_filter('way') }}
+  AND boundary='administrative'
+)
+
 SELECT
-    osm_id AS __id__,
-    {% filter geometry %}way{% endfilter %} AS __geometry__,
-    tags->'border_type' AS kind,
-    name,
-    %#tags AS tags
+    rhs.osm_id AS __id__,
+-- this is taking the right hand polygon, forcing the direction of its
+-- boundary to be clockwise (i.e: polygon on the right). this makes
+-- sure we have a consistent idea of what is to the right. it then
+-- tries to intersect that with each of the left-hand polygons (now
+-- direction doesn't matter, as it should keep the first operand's
+-- direction). it then merges the result to try and keep a smaller
+-- number of line segments.
+    {% filter geometry %}st_linemerge(st_intersection(st_boundary(st_forcerhr(rhs.way)), st_boundary(lhs.way))){% endfilter %} AS __geometry__,
+    coalesce(rhs.tags->'border_type', lhs.tags->'border_type') AS kind,
+    rhs.admin_level as admin_level,
+    (lhs.name || ' - ' || rhs.name) AS name,
+    lhs.name AS lhs_name,
+    rhs.name AS rhs_name,
+    %#(mz_hstore_add_prefix(rhs.tags, 'right:') ||
+       mz_hstore_add_prefix(lhs.tags, 'left:')) AS tags
 FROM
-    planet_osm_line
-WHERE
-    boundary='administrative'
-    AND {{ bounds|bbox_filter('way') }}
+    admin_polygons rhs
+    JOIN admin_polygons lhs
+    ON rhs.osm_id > lhs.osm_id
+    AND rhs.admin_level = lhs.admin_level
+ORDER BY
+    rhs.osm_id ASC, lhs.osm_id ASC
 
 {% endif %}

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -27,6 +27,8 @@ WHERE
 UNION
 
 SELECT
+    name_l AS lhs_name,
+    name_r AS rhs_name,
     {{ ne_boundary_cols('state') }}
 FROM
     ne_50m_admin_1_states_provinces_lines


### PR DESCRIPTION
Query for geometry and attributes both sides of a boundary.

WARNING: This might have a profound change on what data is available in the tiles.

Previously, the boundaries came from the lines table, where they were hard to link back to the relation via the "rels" table, and didn't provide easy left/right distinction without intensive efforts to reconstruct the whole boundary topology.

Instead, this works around the issue by extracting the admin area polygons at matching `admin_level`s, ensures that the boundary of one is correctly oriented and uses the shared portions of boundary to reconstruct the original. This _should_ work, as long as it is done before any simplification steps.

For example, just looking at the name attribute:

![boundaries_names_inline](https://cloud.githubusercontent.com/assets/271360/9909130/c48e8d3e-5c8e-11e5-9415-36f900798ad8.png)

Or, using the translations in the `left:name:*` and `right:name:*`:

![boundaries_left_right_translation](https://cloud.githubusercontent.com/assets/271360/9909152/d58b211a-5c8e-11e5-93fa-68cc2cab7cf0.png)

Using the following scene file fragment:

```yaml
    boundaries:
      data: { source: osm }
      draw:
        lines:
          order: 4
          color: '#808080'
          width: 2px
      admin_4:
	filter: { admin_level: '4' }
        draw:
          lines:
            width: 6px
          text:
            text_source: |
              function() {                                                                  
                return feature['left:name:el'] + "/" + feature['right:name:el']             
              }                                                                             
            font:
              fill: '#404040'
              typeface: 500 18px Helvetica
              stroke: { color: '#88bbee', width: 4 }
```

Refs #180 & requires mapzen/TileStache#51.

@rmarianski could you review, please?