### PR TITLE
Extract POIs from polygons and filter zoom by area.

### DIFF
--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -6,7 +6,9 @@ BEGIN
 --------------------------------------------------------------------------------
 
 CREATE INDEX planet_osm_point_place_index ON planet_osm_point(place) WHERE name IS NOT NULL AND place IN ('borough', 'city', 'continent', 'country', 'county', 'district', 'farm', 'hamlet', 'island', 'isolated_dwelling', 'lake', 'locality', 'neighbourhood', 'ocean', 'province', 'quarter', 'sea', 'state', 'suburb', 'town', 'village');
-CREATE INDEX planet_osm_point_level_index ON planet_osm_point(mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real)) WHERE mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real) IS NOT NULL;
+-- NOTE: removed index on mz_poi_min_zoom, possibly will replace with
+-- a partial index at some point in the future, depends on how the
+-- query performs.
 
 ALTER TABLE planet_osm_point ADD COLUMN mz_poi_min_zoom SMALLINT;
 -- the coalesce here is just an optimisation, as the poi level

--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -6,6 +6,14 @@ BEGIN
 --------------------------------------------------------------------------------
 
 CREATE INDEX planet_osm_point_place_index ON planet_osm_point(place) WHERE name IS NOT NULL AND place IN ('borough', 'city', 'continent', 'country', 'county', 'district', 'farm', 'hamlet', 'island', 'isolated_dwelling', 'lake', 'locality', 'neighbourhood', 'ocean', 'province', 'quarter', 'sea', 'state', 'suburb', 'town', 'village');
-CREATE INDEX planet_osm_point_level_index ON planet_osm_point(mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway")) WHERE mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway") IS NOT NULL;
+CREATE INDEX planet_osm_point_level_index ON planet_osm_point(mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real)) WHERE mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real) IS NOT NULL;
+
+ALTER TABLE planet_osm_point ADD COLUMN mz_poi_min_zoom SMALLINT;
+-- the coalesce here is just an optimisation, as the poi level
+-- will always be NULL if all of the arguments are NULL.
+UPDATE planet_osm_point SET
+    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real)
+    WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway") IS NOT NULL;
+
 
 END $$;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -49,10 +49,10 @@ DECLARE
   zoom smallint;
 BEGIN
   zoom =
-        CASE WHEN aeroway_val IN ('aerodrome', 'airport') THEN 13
-             WHEN natural_val IN ('peak', 'volcano') THEN 11
+        CASE WHEN natural_val IN ('peak', 'volcano') THEN 11
              WHEN railway_val IN ('station') THEN 12
-             WHEN (aerialway_val IN ('station')
+             WHEN (aeroway_val IN ('aerodrome', 'airport')
+                   OR aerialway_val IN ('station')
                    OR railway_val IN ('halt', 'tram_stop')
                    OR tourism_val IN ('alpine_hut', 'zoo')) THEN 13
              WHEN (natural_val IN ('spring')

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -41,12 +41,15 @@ CREATE OR REPLACE FUNCTION mz_calculate_poi_level(
     railway_val text,
     shop_val text,
     tourism_val text,
-    waterway_val text
+    waterway_val text,
+    way_area real
 )
 RETURNS SMALLINT AS $$
+DECLARE
+  zoom smallint;
 BEGIN
-    RETURN (
-        CASE WHEN aeroway_val IN ('aerodrome', 'airport') THEN 9
+  zoom =
+        CASE WHEN aeroway_val IN ('aerodrome', 'airport') THEN 13
              WHEN natural_val IN ('peak', 'volcano') THEN 11
              WHEN railway_val IN ('station') THEN 12
              WHEN (aerialway_val IN ('station')
@@ -105,8 +108,13 @@ BEGIN
                                     'hostel', 'hotel', 'motel', 'museum')
                    OR railway_val IN ('subway_entrance')) THEN 17
              WHEN (amenity_val IN ('bench', 'waste_basket')) THEN 18
-             ELSE NULL END
-    );
+             ELSE NULL END;
+  RETURN (CASE
+    WHEN way_area > 1.0e7 THEN zoom - 4
+    WHEN way_area > 1.0e6 THEN zoom - 3
+    WHEN way_area > 1.0e5 THEN zoom - 2
+    WHEN way_area > 1.0e4 THEN zoom - 1
+    ELSE zoom END);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -1,15 +1,35 @@
-CREATE OR REPLACE FUNCTION mz_trigger_function_landuse()
+CREATE OR REPLACE FUNCTION mz_trigger_function_polygon()
 RETURNS TRIGGER AS $$
+DECLARE
+    mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power");
+    mz_poi_min_zoom SMALLINT = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW.way_area);
 BEGIN
-    IF mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power") then
+    IF mz_is_landuse THEN
         NEW.mz_is_landuse := TRUE;
-        NEW.mz_centroid := ST_Centroid(NEW.way);
     ELSE
         NEW.mz_is_landuse := NULL;
+    END IF;
+
+    NEW.mz_poi_min_zoom := mz_poi_min_zoom;
+
+    IF mz_is_landuse OR mz_poi_min_zoom IS NOT NULL THEN
+        NEW.mz_centroid := ST_Centroid(NEW.way);
+    ELSE
         NEW.mz_centroid := NULL;
     END IF;
+
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
-CREATE TRIGGER mz_trigger_landuse BEFORE INSERT OR UPDATE ON planet_osm_polygon FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_landuse();
+CREATE TRIGGER mz_trigger_polygon BEFORE INSERT OR UPDATE ON planet_osm_polygon FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_polygon();
+
+CREATE OR REPLACE FUNCTION mz_trigger_function_point()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.mz_poi_min_zoom := mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", 0::real);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+CREATE TRIGGER mz_trigger_point BEFORE INSERT OR UPDATE ON planet_osm_point FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_point();

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -6,48 +6,40 @@ SELECT
     religion,
     sport,
     %#tags AS tags,
-{% if zoom < 11 %}
-    aeroway AS kind
-{% elif zoom == 11 %}
-    COALESCE("aeroway", "natural") AS kind
-{% elif zoom == 12 %}
-    COALESCE("aeroway", "natural", "railway") AS kind
-{% elif zoom == 13 or zoom == 14 %}
-    COALESCE("aerialway", "aeroway", "natural", "railway", "tourism") AS kind
-{% elif zoom == 15 %}
-    COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway",
-             "lock", "man_made", "natural", "power", "railway", "tourism",
-             "waterway") AS kind
-{% elif zoom == 16 %}
-    COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic",
-             "lock", "man_made", "natural", "power", "railway", "shop",
-             "tourism", "waterway") AS kind
-{% elif zoom >= 17 %}
     COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic",
              "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop",
              "tourism", "waterway") AS kind
-{% endif %}
 
-FROM planet_osm_point
+FROM (
 
-WHERE
+  SELECT
+    name, way, 0::real AS way_area, mz_poi_min_zoom AS min_zoom,
+    osm_id,
+    cuisine, religion, sport,
+    aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
+    tags
+
+  FROM
+    planet_osm_point
+
+  WHERE
     {{ bounds|bbox_filter('way') }}
-    AND mz_calculate_poi_level(
-        "aerialway",
-        "aeroway",
-        "amenity",
-        "barrier",
-        "craft",
-        "highway",
-        "historic",
-        "leisure",
-        "lock",
-        "man_made",
-        "natural",
-        "office",
-        "power",
-        "railway",
-        "shop",
-        "tourism",
-        "waterway"
-    ) <= {{ zoom }}
+    AND mz_poi_min_zoom <= {{ zoom }}
+
+UNION ALL
+
+  SELECT
+    name, st_centroid(way) AS way, way_area, mz_poi_min_zoom AS min_zoom,
+    osm_id,
+    cuisine, religion, sport,
+    aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
+    tags
+
+  FROM
+    planet_osm_polygon
+
+  WHERE
+    {{ bounds|bbox_filter('way') }}
+    AND mz_poi_min_zoom <= {{ zoom }}
+
+) points_and_centroids

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -29,7 +29,7 @@ FROM (
 UNION ALL
 
   SELECT
-    name, st_centroid(way) AS way, way_area, mz_poi_min_zoom AS min_zoom,
+    name, mz_centroid AS way, way_area, mz_poi_min_zoom AS min_zoom,
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,


### PR DESCRIPTION
Previously, the POIs had just been coming from the `planet_osm_point` table, but some POIs are represented as polygons. These are included via their centroid, and the same test function `mz_calculate_poi_level`.

That function has been modified to adjust the zoom based on the feature's area. Note that this will probably mean we want to take another look at the zoom levels that some of these get assigned in the function and adjust based on the distribution of areas for those feature types.

Finally, the `mz_calculate_poi_level` function gets called almost a million times for a mid-zoom tile and, even though it's pretty quick, that's just too slow. The POI `min_zoom` is reified as a column in both the points and polygons tables and kept up to date with a trigger (yuck...). That brings the query time for a mid-zoom tile down from 4s to about 5ms.

Refs #195.

@rmarianski could you review, please?