### PR TITLE
Use UNION ALL instead of UNION.

### DIFF
--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -24,7 +24,7 @@ FROM
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     {{ ne_boundary_cols('state') }}
@@ -46,7 +46,7 @@ FROM
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     name,

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -50,7 +50,7 @@ WHERE
 
 {% if zoom >= 17 %}
 
-UNION
+UNION ALL
 
 SELECT
     name,

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -26,7 +26,7 @@ FROM
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     name,

--- a/queries/water.jinja2
+++ b/queries/water.jinja2
@@ -22,7 +22,7 @@ FROM ne_10m_ocean
 
 WHERE {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     name,
@@ -39,7 +39,7 @@ FROM ne_10m_lakes
 WHERE {{ bounds|bbox_filter('the_geom') }}
 GROUP BY name
 
-UNION
+UNION ALL
 
 SELECT
     NULL AS name,
@@ -61,7 +61,7 @@ FROM
 
 WHERE {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     NULL AS name,
@@ -84,7 +84,7 @@ FROM
 WHERE {{ bounds|bbox_filter('the_geom') }}
 
 {% if 4 <= zoom < 9 %}
-UNION
+UNION ALL
 
 SELECT
     name,
@@ -99,7 +99,7 @@ FROM ne_10m_playas
 WHERE {{ bounds|bbox_filter('the_geom') }}
 GROUP BY name
 
-UNION
+UNION ALL
 
 SELECT
     NULL AS name,
@@ -135,7 +135,7 @@ FROM water_polygons
 
 WHERE {{ bounds|bbox_filter('the_geom') }}
 
-UNION
+UNION ALL
 
 SELECT
     name,
@@ -165,7 +165,7 @@ WHERE
     AND way_area::bigint > 100
 {% endif %}
 
-UNION
+UNION ALL
 
 SELECT
     name,


### PR DESCRIPTION
Turns out, it was always appropriate to use `UNION ALL` in our queries, as we were either selecting from different tables with definitely different data, or selecting different attributes anyway.

@rmarianski could you review, please?