### PR TITLE
Tweak NE to OSM transition

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -122,7 +122,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
-        CASE WHEN highway_val IN ('motorway', 'trunk', 'primary', 'motorway_link') THEN 9
+        CASE WHEN highway_val IN ('motorway', 'trunk', 'primary', 'motorway_link') THEN 8
              WHEN highway_val IN ('secondary') THEN 10
              WHEN (highway_val IN ('tertiary')
                 OR aeroway_val IN ('runway', 'taxiway')) THEN 11

--- a/queries.yaml
+++ b/queries.yaml
@@ -53,7 +53,7 @@ layers:
     template: landuse.jinja2
     start_zoom: 4
     geometry_types: [Polygon, MultiPolygon]
-    simplify_start: 9
+    simplify_start: 8
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n

--- a/queries.yaml
+++ b/queries.yaml
@@ -82,7 +82,7 @@ layers:
     template: roads.jinja2
     start_zoom: 5
     geometry_types: [LineString, MultiLineString]
-    simplify_start: 9
+    simplify_start: 8
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n

--- a/queries.yaml
+++ b/queries.yaml
@@ -66,7 +66,7 @@ layers:
     sort: TileStache.Goodies.VecTiles.sort.landuse
   landuse_labels:
     template: landuse_labels.jinja2
-    start_zoom: 9
+    start_zoom: 8
     geometry_types: [Point, MultiPoint]
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -91,7 +91,8 @@ FROM
     JOIN admin_polygons lhs
     ON rhs.osm_id > lhs.osm_id
     AND rhs.admin_level = lhs.admin_level
+    AND rhs.way && lhs.way
 ORDER BY
-    rhs.osm_id ASC, lhs.osm_id ASC
+    rhs.admin_level ASC
 
 {% endif %}

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -16,7 +16,7 @@ FROM
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
-{% elif 6 <= zoom < 9 %}
+{% elif 6 <= zoom < 8 %}
 
 SELECT
     '' AS name,
@@ -54,7 +54,9 @@ WHERE
     mz_is_landuse = TRUE
     AND {{ bounds|bbox_filter('way') }}
 
-    {% if zoom == 9 %}
+    {% if zoom == 8 %}
+    AND way_area::bigint > 1638400
+    {% elif zoom == 9 %}
     AND way_area::bigint > 409600
     {% elif zoom == 10 %}
     AND way_area::bigint > 102400

--- a/queries/landuse_labels.jinja2
+++ b/queries/landuse_labels.jinja2
@@ -18,7 +18,9 @@ WHERE
     {% endif %}
     AND {{ bounds|bbox_filter('way') }}
 
-    {% if zoom == 9 %}
+    {% if zoom == 8 %}
+    AND way_area::bigint > 1638400
+    {% elif zoom == 9 %}
     AND way_area::bigint > 409600
     {% elif zoom == 10 %}
     AND way_area::bigint > 102400

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -1,4 +1,4 @@
-{% if zoom < 9 %}
+{% if zoom < 8 %}
 SELECT
     gid AS __id__,
     {% filter geometry %}the_geom{% endfilter %} AS __geometry__,

--- a/queries/water.jinja2
+++ b/queries/water.jinja2
@@ -46,7 +46,7 @@ SELECT
     NULL AS area,
     'ocean' AS kind,
     'naturalearthdata.com' AS source,
-    the_geom AS __geometry__,
+    {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
     gid AS __id__,
     'yes' AS boundary
 
@@ -68,7 +68,7 @@ SELECT
     NULL AS area,
     'lake' AS kind,
     'naturalearthdata.com' AS source,
-    st_boundary(the_geom) AS __geometry__,
+    {% filter geometry %}st_boundary(the_geom){% endfilter %} AS __geometry__,
     gid AS __id__,
     'yes' AS boundary
 
@@ -106,7 +106,7 @@ SELECT
     NULL AS area,
     'playa' AS kind,
     'naturalearthdata.com' AS source,
-    st_boundary(the_geom) AS __geometry__,
+    {% filter geometry %}st_boundary(the_geom){% endfilter %} AS __geometry__,
     gid AS __id__,
     'yes' AS boundary
 


### PR DESCRIPTION
Refs #205.

This changes the zoom test for NE from `<9` to `<8` for landuse, landuse labels and roads. Boundaries were already `<8`.

Additionally, made a couple of fixes to existing layers:

* Minor speed-up to boundaries by doing including a bbox `&&` test as part of the join condition. This helps at lower zooms where there are many county boundaries. Better would be to cut them out at, say, zoom 10 and lower if we don't need to render them.
* Several queries in the water layer weren't returning their responses `ST_AsBinary()`, but this didn't seem to cause any problems. In any case, for consistency, they all now have that.

@rmarianski, could you review, please?