### PR TITLE
Added OSM-based national park polygons at zooms 4-8.

### DIFF
--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -19,7 +19,7 @@ ALTER TABLE planet_osm_polygon ADD COLUMN mz_poi_min_zoom SMALLINT;
 
 UPDATE planet_osm_polygon SET
     mz_is_landuse = TRUE
-    WHERE mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power") = TRUE;
+    WHERE mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power", "boundary") = TRUE;
 
 -- the coalesce here is just an optimisation, as the poi level
 -- will always be NULL if all of the arguments are NULL.

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -53,6 +53,11 @@ BEGIN
       WHEN boundary_val IN (
         'national_park', 'protected_area')
 	THEN boundary_val
+      -- promote this above landuse as it's more specific, and we
+      -- don't want to lump nature reserves in with all of the
+      -- generic forests.
+      WHEN leisure_val = 'nature_reserve'
+        THEN leisure_val
       WHEN landuse_val IN (
         'park', 'forest', 'residential', 'retail', 'commercial', 'industrial',
 	'railway', 'cemetery', 'grass', 'farmyard', 'farm', 'farmland', 'wood',
@@ -61,7 +66,7 @@ BEGIN
         THEN landuse_val
       WHEN leisure_val IN (
         'park', 'garden', 'playground', 'golf_course', 'sports_centre', 'pitch',
-	'stadium', 'common', 'nature_reserve')
+	'stadium', 'common')
 	THEN leisure_val
       WHEN natural_val IN (
         'wood', 'land', 'scrub', 'wetland', 'glacier')

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1,3 +1,5 @@
+-- IF YOU UPDATE THIS, PLEASE UPDATE mz_calculate_landuse_kind
+-- BELOW!
 CREATE OR REPLACE FUNCTION mz_calculate_is_landuse(
     landuse_val text, leisure_val text, natural_val text, highway_val text,
     amenity_val text, aeroway_val text, tourism_val text, man_made_val text,
@@ -22,6 +24,69 @@ BEGIN
                          'breakwater', 'water_works', 'groyne', 'dike', 'cutline')
      OR power_val IN   ('plant', 'generator', 'substation', 'station', 'sub_station')
      OR boundary_val IN ('national_park', 'protected_area');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- calculate the collapse of several properties onto one string
+-- 'kind'. this involves a series of precedence choices, as
+-- it's possible for a feature to have values in several of
+-- these categories. in general, the "most important" should go
+-- first, or its presence should modify the later.
+--
+-- IF YOU UPDATE THIS, PLEASE UPDATE mz_calculate_is_landuse
+-- ABOVE!
+CREATE OR REPLACE FUNCTION mz_calculate_landuse_kind(
+  landuse_val text,
+  leisure_val text,
+  natural_val text,
+  highway_val text,
+  aeroway_val text,
+  amenity_val text,
+  tourism_val text,
+  man_made_val text,
+  power_val text,
+  boundary_val text)
+RETURNS text AS $$
+BEGIN
+  RETURN
+    CASE
+      WHEN boundary_val IN (
+        'national_park', 'protected_area')
+	THEN boundary_val
+      WHEN landuse_val IN (
+        'park', 'forest', 'residential', 'retail', 'commercial', 'industrial',
+	'railway', 'cemetery', 'grass', 'farmyard', 'farm', 'farmland', 'wood',
+	'meadow', 'village_green', 'recreation_ground', 'allotments', 'quarry',
+	'urban', 'rural', 'military')
+        THEN landuse_val
+      WHEN leisure_val IN (
+        'park', 'garden', 'playground', 'golf_course', 'sports_centre', 'pitch',
+	'stadium', 'common', 'nature_reserve')
+	THEN leisure_val
+      WHEN natural_val IN (
+        'wood', 'land', 'scrub', 'wetland', 'glacier')
+	THEN natural_val
+      WHEN highway_val IN (
+        'pedestrian', 'footway')
+	THEN highway_val
+      WHEN amenity_val IN (
+        'university', 'school', 'college', 'library', 'fuel', 'parking',
+	'cinema', 'theatre', 'place_of_worship', 'hospital')
+	THEN amenity_val
+      WHEN aeroway_val IN (
+        'runway', 'taxiway', 'apron', 'aerodrome')
+	THEN aeroway_val
+      WHEN tourism_val IN (
+        'zoo')
+	THEN tourism_val
+      WHEN man_made_val IN (
+        'pier', 'wastewater_plant', 'works', 'bridge', 'tower', 'breakwater',
+	'water_works', 'groyne', 'dike', 'cutline')
+	THEN man_made_val
+      WHEN power_val IN (
+        'plant', 'generator', 'substation', 'station', 'sub_station')
+	THEN power_val
+      ELSE NULL END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
@@ -305,65 +370,5 @@ CREATE OR REPLACE FUNCTION mz_one_pixel_zoom(
 RETURNS real AS $$
 BEGIN
   RETURN (17.256-ln(way_area)/ln(4));
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
--- calculate the collapse of several properties onto one string
--- 'kind'. this involves a series of precedence choices, as
--- it's possible for a feature to have values in several of
--- these categories. in general, the "most important" should go
--- first, or its presence should modify the later.
-CREATE OR REPLACE FUNCTION mz_calculate_landuse_kind(
-  landuse_val text,
-  leisure_val text,
-  natural_val text,
-  highway_val text,
-  aeroway_val text,
-  amenity_val text,
-  tourism_val text,
-  man_made_val text,
-  power_val text,
-  boundary_val text)
-RETURNS text AS $$
-BEGIN
-  RETURN
-    CASE
-      WHEN boundary_val IN (
-        'national_park', 'protected_area')
-	THEN boundary_val
-      WHEN landuse_val IN (
-        'park', 'forest', 'residential', 'retail', 'commercial', 'industrial',
-	'railway', 'cemetery', 'grass', 'farmyard', 'farm', 'farmland', 'wood',
-	'meadow', 'village_green', 'recreation_ground', 'allotments', 'quarry',
-	'urban', 'rural', 'military')
-        THEN landuse_val
-      WHEN leisure_val IN (
-        'park', 'garden', 'playground', 'golf_course', 'sports_centre', 'pitch',
-	'stadium', 'common', 'nature_reserve')
-	THEN leisure_val
-      WHEN natural_val IN (
-        'wood', 'land', 'scrub', 'wetland', 'glacier')
-	THEN natural_val
-      WHEN highway_val IN (
-        'pedestrian', 'footway')
-	THEN highway_val
-      WHEN amenity_val IN (
-        'university', 'school', 'college', 'library', 'fuel', 'parking',
-	'cinema', 'theatre', 'place_of_worship', 'hospital')
-	THEN amenity_val
-      WHEN aeroway_val IN (
-        'runway', 'taxiway', 'apron', 'aerodrome')
-	THEN aeroway_val
-      WHEN tourism_val IN (
-        'zoo')
-	THEN tourism_val
-      WHEN man_made_val IN (
-        'pier', 'wastewater_plant', 'works', 'bridge', 'tower', 'breakwater',
-	'water_works', 'groyne', 'dike', 'cutline')
-	THEN man_made_val
-      WHEN power_val IN (
-        'plant', 'generator', 'substation', 'station', 'sub_station')
-	THEN power_val
-      ELSE NULL END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION mz_calculate_is_landuse(
     landuse_val text, leisure_val text, natural_val text, highway_val text,
     amenity_val text, aeroway_val text, tourism_val text, man_made_val text,
-    power_val text)
+    power_val text, boundary_val text)
 RETURNS BOOLEAN AS $$
 BEGIN
     RETURN
@@ -20,7 +20,8 @@ BEGIN
      OR tourism_val IN ('zoo')
      OR man_made_val IN ('pier', 'wastewater_plant', 'works', 'bridge', 'tower',
                          'breakwater', 'water_works', 'groyne', 'dike', 'cutline')
-     OR power_val IN   ('plant', 'generator', 'substation', 'station', 'sub_station');
+     OR power_val IN   ('plant', 'generator', 'substation', 'station', 'sub_station')
+     OR boundary_val IN ('national_park');
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -292,3 +292,17 @@ BEGIN
   RETURN new_tags;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- returns the (possibly fractional) zoom at which the given way
+-- area will be one square pixel nominally on screen (assuming
+-- that tiles are 256x256px at integer zooms). sadly, features
+-- aren't always rectangular and axis-aligned, but this should
+-- still give a reasonable approximation to the zoom that it
+-- would be appropriate to show them.
+CREATE OR REPLACE FUNCTION mz_one_pixel_zoom(
+  way_area real)
+RETURNS real AS $$
+BEGIN
+  RETURN (17.256-ln(way_area)/ln(4));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION mz_trigger_function_polygon()
 RETURNS TRIGGER AS $$
 DECLARE
-    mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power");
+    mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary");
     mz_poi_min_zoom SMALLINT = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW.way_area);
 BEGIN
     IF mz_is_landuse THEN

--- a/queries.yaml
+++ b/queries.yaml
@@ -53,7 +53,7 @@ layers:
     template: landuse.jinja2
     start_zoom: 4
     geometry_types: [Polygon, MultiPolygon]
-    simplify_start: 9
+    simplify_start: 4
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n

--- a/queries.yaml
+++ b/queries.yaml
@@ -66,7 +66,7 @@ layers:
     sort: TileStache.Goodies.VecTiles.sort.landuse
   landuse_labels:
     template: landuse_labels.jinja2
-    start_zoom: 9
+    start_zoom: 4
     geometry_types: [Point, MultiPoint]
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict

--- a/queries.yaml
+++ b/queries.yaml
@@ -53,11 +53,7 @@ layers:
     template: landuse.jinja2
     start_zoom: 4
     geometry_types: [Polygon, MultiPolygon]
-<<<<<<< HEAD
     simplify_start: 4
-=======
-    simplify_start: 8
->>>>>>> origin/master
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -1,4 +1,6 @@
 {% macro ne_landuse_cols(kind) %}
+    NULL AS protect_class,
+    NULL AS operator,
     way_area::bigint AS area,
     '{{ kind }}' AS kind,
     'naturalearthdata.com' AS source,
@@ -10,7 +12,6 @@
 
 SELECT
     '' AS name,
-    NULL AS protect_class,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_50m_urban_areas
@@ -22,6 +23,7 @@ UNION ALL
 SELECT
   name,
   tags->'protect_class' AS protect_class,
+  operator,
   way_area::bigint AS area,
   mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
   'openstreetmap.org' AS source,
@@ -31,14 +33,13 @@ FROM
   planet_osm_polygon
 WHERE
   {{ bounds|bbox_filter('way') }}
-  AND boundary='national_park'
+  AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
 {% elif 6 <= zoom < 8 %}
 
 SELECT
     '' AS name,
-    NULL AS protect_class,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_10m_urban_areas
@@ -50,6 +51,7 @@ UNION ALL
 SELECT
   name,
   tags->'protect_class' AS protect_class,
+  operator,
   way_area::bigint AS area,
   mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
   'openstreetmap.org' AS source,
@@ -59,7 +61,7 @@ FROM
   planet_osm_polygon
 WHERE
   {{ bounds|bbox_filter('way') }}
-  AND boundary IN ('national_park', 'protected_area')
+  AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
 {% else %}
@@ -68,6 +70,7 @@ SELECT
     name,
     way_area::bigint AS area,
     tags->'protect_class' AS protect_class,
+    operator,
     mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}way{% endfilter %} AS __geometry__,

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -10,16 +10,35 @@
 
 SELECT
     '' AS name,
+    NULL as operator,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_50m_urban_areas
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
+UNION ALL
+
+SELECT
+  name,
+  operator,
+  way_area::bigint AS area,
+  COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+  'openstreetmap.org' AS source,
+  {% filter geometry %}way{% endfilter %} AS __geometry__,
+  osm_id AS __id__
+FROM
+  planet_osm_polygon
+WHERE
+  {{ bounds|bbox_filter('way') }}
+  AND boundary='national_park'
+  AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
+
 {% elif 6 <= zoom < 9 %}
 
 SELECT
     '' AS name,
+    NULL as operator,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_10m_urban_areas
@@ -29,19 +48,27 @@ WHERE
 UNION ALL
 
 SELECT
-    name,
-    {{ ne_landuse_cols('park or protected land') }}
+  name,
+  operator,
+  way_area::bigint AS area,
+  COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+  'openstreetmap.org' AS source,
+  {% filter geometry %}way{% endfilter %} AS __geometry__,
+  osm_id AS __id__
 FROM
-    ne_10m_parks_and_protected_lands
+  planet_osm_polygon
 WHERE
-    {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds|bbox_filter('way') }}
+  AND boundary='national_park'
+  AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
 
 {% else %}
 
 SELECT
     name,
     way_area::bigint AS area,
-    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+    operator,
+    COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
     osm_id AS __id__,
@@ -53,21 +80,8 @@ FROM
 WHERE
     mz_is_landuse = TRUE
     AND {{ bounds|bbox_filter('way') }}
-
-    {% if zoom == 9 %}
-    AND way_area::bigint > 409600
-    {% elif zoom == 10 %}
-    AND way_area::bigint > 102400
-    {% elif zoom == 11 %}
-    AND way_area::bigint > 25600
-    {% elif zoom == 12 %}
-    AND way_area::bigint > 6400
-    {% elif zoom == 13 %}
-    AND way_area::bigint > 1600
-    {% elif zoom == 14 %}
-    AND way_area::bigint > 400
-    {% elif zoom == 15 %}
-    AND way_area::bigint > 100
+    {% if zoom <= 15 %}
+    AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
     {% endif %}
 
 {% endif %}

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -17,7 +17,6 @@ FROM
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
 
-<<<<<<< HEAD
 UNION ALL
 
 SELECT
@@ -35,10 +34,7 @@ WHERE
   AND boundary='national_park'
   AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
-{% elif 6 <= zoom < 9 %}
-=======
 {% elif 6 <= zoom < 8 %}
->>>>>>> origin/master
 
 SELECT
     '' AS name,

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -32,7 +32,7 @@ FROM
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND boundary='national_park'
-  AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
+  AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
 {% elif 6 <= zoom < 9 %}
 
@@ -60,7 +60,7 @@ FROM
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND boundary='national_park'
-  AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
+  AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
 {% else %}
 
@@ -81,7 +81,7 @@ WHERE
     mz_is_landuse = TRUE
     AND {{ bounds|bbox_filter('way') }}
     {% if zoom <= 15 %}
-    AND (17.256-ln(way_area)/ln(4)) <= {{ zoom }}
+    AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
     {% endif %}
 
 {% endif %}

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -10,7 +10,7 @@
 
 SELECT
     '' AS name,
-    NULL as operator,
+    NULL AS protect_class,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_50m_urban_areas
@@ -21,9 +21,9 @@ UNION ALL
 
 SELECT
   name,
-  operator,
+  tags->'protect_class' AS protect_class,
   way_area::bigint AS area,
-  COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+  mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
   'openstreetmap.org' AS source,
   {% filter geometry %}way{% endfilter %} AS __geometry__,
   osm_id AS __id__
@@ -38,7 +38,7 @@ WHERE
 
 SELECT
     '' AS name,
-    NULL as operator,
+    NULL AS protect_class,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_10m_urban_areas
@@ -49,9 +49,9 @@ UNION ALL
 
 SELECT
   name,
-  operator,
+  tags->'protect_class' AS protect_class,
   way_area::bigint AS area,
-  COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+  mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
   'openstreetmap.org' AS source,
   {% filter geometry %}way{% endfilter %} AS __geometry__,
   osm_id AS __id__
@@ -59,7 +59,7 @@ FROM
   planet_osm_polygon
 WHERE
   {{ bounds|bbox_filter('way') }}
-  AND boundary='national_park'
+  AND boundary IN ('national_park', 'protected_area')
   AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
 
 {% else %}
@@ -67,8 +67,8 @@ WHERE
 SELECT
     name,
     way_area::bigint AS area,
-    operator,
-    COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+    tags->'protect_class' AS protect_class,
+    mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
     osm_id AS __id__,

--- a/queries/landuse_labels.jinja2
+++ b/queries/landuse_labels.jinja2
@@ -1,7 +1,28 @@
+{% if 4 <= zoom < 9 %}
+
+SELECT
+  name,
+  tags->'protect_class' AS protect_class,
+  way_area::bigint AS area,
+  mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
+  'openstreetmap.org' AS source,
+  {% filter geometry %}way{% endfilter %} AS __geometry__,
+  osm_id AS __id__
+FROM
+  planet_osm_polygon
+WHERE
+  {{ bounds|bbox_filter('way') }}
+  AND name IS NOT NULL
+  AND boundary IN ('national_park', 'protected_area')
+  AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
+
+{% else %}
+
 SELECT
     name,
     way_area::bigint AS area,
-    COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+    tags->'protect_class' AS protect_class,
+    mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}mz_centroid{% endfilter %} AS __geometry__,
     osm_id AS __id__,
@@ -17,19 +38,8 @@ WHERE
     AND (amenity IS NULL OR amenity != 'parking')
     {% endif %}
     AND {{ bounds|bbox_filter('way') }}
-
-    {% if zoom == 9 %}
-    AND way_area::bigint > 409600
-    {% elif zoom == 10 %}
-    AND way_area::bigint > 102400
-    {% elif zoom == 11 %}
-    AND way_area::bigint > 25600
-    {% elif zoom == 12 %}
-    AND way_area::bigint > 6400
-    {% elif zoom == 13 %}
-    AND way_area::bigint > 1600
-    {% elif zoom == 14 %}
-    AND way_area::bigint > 400
-    {% elif zoom == 15 %}
-    AND way_area::bigint > 100
+    {% if zoom <= 15 %}
+    AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
     {% endif %}
+
+{% endif %}

--- a/queries/landuse_labels.jinja2
+++ b/queries/landuse_labels.jinja2
@@ -1,7 +1,7 @@
 SELECT
     name,
     way_area::bigint AS area,
-    COALESCE("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
+    COALESCE("boundary", "landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}mz_centroid{% endfilter %} AS __geometry__,
     osm_id AS __id__,


### PR DESCRIPTION
This adds those polygons, removing the NE ones which were in some of the queries. The new polygons merge in the `boundary` attribute and update the `mz_calculate_is_landuse` function to treat national park polygons as a type of landuse.

It also exposes an attribute for the OSM `operator` tag, which can be used to distinguish US National Parks Service areas from those run by the US Forestry Service.

Refs #149.

Before, zooms 4-6:

![149-before-z4](https://cloud.githubusercontent.com/assets/271360/10002482/4754ddae-609f-11e5-9c4c-5f640ad646a8.png)

![149-before-z5](https://cloud.githubusercontent.com/assets/271360/10002484/49fdbb34-609f-11e5-8f5a-c0068b2fa83e.png)

![149-before-z6](https://cloud.githubusercontent.com/assets/271360/10002487/4e2f9fe2-609f-11e5-9570-d52c07f422c7.png)

After:

![149-after-z4](https://cloud.githubusercontent.com/assets/271360/10002491/547b6980-609f-11e5-8043-dc322c8b4075.png)

![149-after-z5](https://cloud.githubusercontent.com/assets/271360/10002495/57c690b0-609f-11e5-9978-7202d587b396.png)

![149-after-z6](https://cloud.githubusercontent.com/assets/271360/10002497/5a7ee000-609f-11e5-81b1-c6c87f535ee7.png)

With the following snippet of `scene.yaml`:

```yaml
    landuse:
        data: { source: osm }
        draw:
            polygons:
                order: 1
                color: '#aaaaa0'
        urban:
          filter: { kind: urban area }
          draw:
            polygons:
              order: 2
              color: '#808080'

        park or protected land:
          filter: { kind: national_park }
          draw:
            polygons:
              order: 2
              color: '#80aa80'

          national_forest:
            filter: { operator: [United States Forest Service, US Forest Service, National \
Forest Service] }
            draw: { polygons: { color: '#609060' } }

          national_park:
            filter: { operator: [United States National Park Service, United States Park Se\
rvice, US National Park Service, National Park Service] }
            draw: { polygons: { color: '#50a060' } }
```