### PR TITLE
More tweaks to NE/OSM transition

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -122,7 +122,8 @@ CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
-        CASE WHEN highway_val IN ('motorway', 'trunk', 'primary', 'motorway_link') THEN 8
+        CASE WHEN highway_val IN ('motorway', 'trunk', 'motorway_link') THEN 8
+             WHEN highway_val IN ('primary') THEN 9
              WHEN highway_val IN ('secondary') THEN 10
              WHEN (highway_val IN ('tertiary')
                 OR aeroway_val IN ('runway', 'taxiway')) THEN 11

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -72,4 +72,20 @@ WHERE
     AND way_area::bigint > 100
     {% endif %}
 
+{% if zoom < 10 %}
+UNION ALL
+
+-- "cross-fade" NE urban area polygons for a couple of zooms.
+SELECT
+  '' AS name,
+  {{ ne_landuse_cols('urban area') }},
+  NULL AS sport,
+  NULL AS religion,
+  NULL AS tags
+FROM
+  ne_10m_urban_areas
+WHERE
+  {{ bounds|bbox_filter('the_geom') }}
+{% endif %}
+
 {% endif %}


### PR DESCRIPTION
Primary roads clutter the map at zoom 8, push them back to zoom 9. Also the `motorway`/`trunk` roads seem to be closer to the road selection on NE.

Keep NE urban areas a couple more zooms [as discussed](https://github.com/mapzen/vector-datasource/issues/149#issuecomment-142132701).

**NOTE**: changes to road level function require dropping & recreating that index.

![205_after_z7](https://cloud.githubusercontent.com/assets/271360/10018467/e1254394-612e-11e5-9b06-1b6e5a7246df.png)

![205_after_z8](https://cloud.githubusercontent.com/assets/271360/10018469/e4b2adf8-612e-11e5-949f-0e83aa2bdc92.png)

![205_after_z9](https://cloud.githubusercontent.com/assets/271360/10018472/e79c681a-612e-11e5-8ae0-02d46db3b4a7.png)

Note that the red bits of road in those images are not just the bits which are outside urban "landuse", but also those which clip a different kind of landuse which I didn't put a rendering rule in for, so they're not intersection errors.

@rmarianski could you review, please?
