### PR TITLE
Add a `maritime` tag onto boundaries

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -174,3 +174,6 @@ post_process:
     attribute: kind
     target_attribute: landuse_kind
     cutting_attrs: { sort_key: 'order', reverse: True }
+  TileStache.Goodies.VecTiles.transform.intracut:
+    base_layer: boundaries
+    attribute: maritime

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -108,41 +108,33 @@ maritime_boundaries AS (
 
 SELECT
   boundaries.__id__,
-  {% filter geometry %}st_intersection(boundaries.way,maritime_boundaries.way){% endfilter %} AS __geometry__,
+  {% filter geometry %}boundaries.way{% endfilter %} AS __geometry__,
   boundaries.kind AS kind,
   boundaries.admin_level AS admin_level,
   boundaries.name AS name,
   boundaries.lhs_name AS lhs_name,
   boundaries.rhs_name AS rhs_name,
   boundaries.tags AS tags,
-  'yes' AS maritime
+  NULL AS maritime
 FROM
   boundaries
-  JOIN maritime_boundaries
-  ON boundaries.way && maritime_boundaries.way
 
 UNION ALL
 
+-- NOTE: we select these here, but we don't actually put them
+-- in the tiles as-is. instead, we project their attributes
+-- onto parts of the existing boundaries selected above.
 SELECT
-  boundaries.__id__,
-  {% filter geometry %}
-    CASE
-      WHEN maritime_boundaries.way IS NULL
-        THEN boundaries.way
-      ELSE
-        st_difference(boundaries.way,maritime_boundaries.way)
-    END
-  {% endfilter %} AS __geometry__,
-  boundaries.kind AS kind,
-  boundaries.admin_level AS admin_level,
-  boundaries.name AS name,
-  boundaries.lhs_name AS lhs_name,
-  boundaries.rhs_name AS rhs_name,
-  boundaries.tags AS tags,
-  'no' AS maritime
+  0::bigint AS __id__,
+  {% filter geometry %}maritime_boundaries.way{% endfilter %} AS __geometry__,
+  NULL AS kind,
+  NULL AS admin_level,
+  NULL AS name,
+  NULL AS lhs_name,
+  NULL AS rhs_name,
+  NULL AS tags,
+  'yes' AS maritime
 FROM
-  boundaries
-  LEFT OUTER JOIN maritime_boundaries
-  ON TRUE
+  maritime_boundaries
 
 {% endif %}

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -67,9 +67,9 @@ WITH admin_polygons AS (
   WHERE
     {{ bounds|bbox_filter('way') }}
   AND boundary='administrative'
-)
-
-SELECT
+),
+boundaries AS (
+  SELECT
     rhs.osm_id AS __id__,
 -- this is taking the right hand polygon, forcing the direction of its
 -- boundary to be clockwise (i.e: polygon on the right). this makes
@@ -78,7 +78,7 @@ SELECT
 -- direction doesn't matter, as it should keep the first operand's
 -- direction). it then merges the result to try and keep a smaller
 -- number of line segments.
-    {% filter geometry %}st_linemerge(st_intersection(st_boundary(st_forcerhr(rhs.way)), st_boundary(lhs.way))){% endfilter %} AS __geometry__,
+    st_linemerge(st_intersection(st_boundary(st_forcerhr(rhs.way)), st_boundary(lhs.way))) AS way,
     coalesce(rhs.tags->'border_type', lhs.tags->'border_type') AS kind,
     rhs.admin_level as admin_level,
     (lhs.name || ' - ' || rhs.name) AS name,
@@ -86,13 +86,63 @@ SELECT
     rhs.name AS rhs_name,
     %#(mz_hstore_add_infix(rhs.tags, 'right') ||
        mz_hstore_add_infix(lhs.tags, 'left')) AS tags
-FROM
+  FROM
     admin_polygons rhs
     JOIN admin_polygons lhs
     ON rhs.osm_id > lhs.osm_id
     AND rhs.admin_level = lhs.admin_level
     AND rhs.way && lhs.way
-ORDER BY
+  ORDER BY
     rhs.admin_level ASC
+),
+maritime_boundaries AS (
+  SELECT
+    st_linemerge(st_collect(way)) AS way
+  FROM
+    planet_osm_line
+  WHERE
+    {{ bounds|bbox_filter('way') }} AND
+    boundary = 'administrative' AND
+    tags->'maritime' = 'yes'
+)
+
+SELECT
+  boundaries.__id__,
+  {% filter geometry %}st_intersection(boundaries.way,maritime_boundaries.way){% endfilter %} AS __geometry__,
+  boundaries.kind AS kind,
+  boundaries.admin_level AS admin_level,
+  boundaries.name AS name,
+  boundaries.lhs_name AS lhs_name,
+  boundaries.rhs_name AS rhs_name,
+  boundaries.tags AS tags,
+  'yes' AS maritime
+FROM
+  boundaries
+  JOIN maritime_boundaries
+  ON boundaries.way && maritime_boundaries.way
+
+UNION ALL
+
+SELECT
+  boundaries.__id__,
+  {% filter geometry %}
+    CASE
+      WHEN maritime_boundaries.way IS NULL
+        THEN boundaries.way
+      ELSE
+        st_difference(boundaries.way,maritime_boundaries.way)
+    END
+  {% endfilter %} AS __geometry__,
+  boundaries.kind AS kind,
+  boundaries.admin_level AS admin_level,
+  boundaries.name AS name,
+  boundaries.lhs_name AS lhs_name,
+  boundaries.rhs_name AS rhs_name,
+  boundaries.tags AS tags,
+  'no' AS maritime
+FROM
+  boundaries
+  LEFT OUTER JOIN maritime_boundaries
+  ON TRUE
 
 {% endif %}


### PR DESCRIPTION
Add a `maritime` tag onto boundaries, which is `yes` when the original boundary way from OSM had a `maritime=yes` tag.

Note that this doesn't correspond to only the "3 nautical mile" boundaries to international waters, it looks like a very large number (but not all) of the boundaries which occur in water or rivers are marked this way too.

Note also that this also adds some run-time overhead. Because we're using geometry from the admin polygon boundaries to supply boundaries with correct left/right orientation and name properties, we need to operate on the original, unsimplified geometry in the post-processor and requires mapzen/TileStache#54.

Refs #210. For screenshots, see the parent issue.

@rmarianski could you review, please?