### PR TITLE
Re-order fields in UNION so that they are consistent.

### DIFF
--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -68,9 +68,9 @@ WHERE
 
 SELECT
     name,
-    way_area::bigint AS area,
     tags->'protect_class' AS protect_class,
     operator,
+    way_area::bigint AS area,
     mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
     'openstreetmap.org' AS source,
     {% filter geometry %}way{% endfilter %} AS __geometry__,


### PR DESCRIPTION
This was causing an issue on tiles:

```
ERROR:  UNION types text and bigint cannot be matched at character 828
```

Or similar.

@rmarianski could you review, please?