### PR TITLE
Add explicit min zoom column on landuse

### DIFF
--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -16,9 +16,11 @@ CREATE INDEX planet_osm_polygon_is_water_index ON planet_osm_polygon(mz_calculat
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_is_landuse BOOLEAN;
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_centroid GEOMETRY;
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_poi_min_zoom REAL;
+ALTER TABLE planet_osm_polygon ADD COLUMN mz_landuse_min_zoom REAL;
 
 UPDATE planet_osm_polygon SET
-    mz_is_landuse = TRUE
+    mz_is_landuse = TRUE,
+    mz_landuse_min_zoom = mz_calculate_landuse_min_zoom("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power", "boundary", way_area)
     WHERE mz_calculate_is_landuse("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power", "boundary") = TRUE;
 
 -- the coalesce here is just an optimisation, as the poi level

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -411,3 +411,30 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION mz_calculate_landuse_min_zoom(
+  landuse_val TEXT,
+  leisure_val TEXT,
+  natural_val TEXT,
+  highway_val TEXT,
+  amenity_val TEXT,
+  aeroway_val TEXT,
+  tourism_val TEXT,
+  man_made_val TEXT,
+  power_val TEXT,
+  boundary_val TEXT,
+  way_area REAL)
+RETURNS REAL AS $$
+DECLARE
+  zoom REAL;
+BEGIN
+  zoom = mz_one_pixel_zoom(way_area);
+  RETURN
+    CASE
+      WHEN (boundary_val IN ('national_park', 'protected_area')
+            OR leisure_val = 'nature_reserve')
+        THEN zoom
+      ELSE
+        GREATEST(LEAST(zoom, 16), 9)
+    END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -6,8 +6,10 @@ DECLARE
 BEGIN
     IF mz_is_landuse THEN
         NEW.mz_is_landuse := TRUE;
+        NEW.mz_landuse_min_zoom := mz_calculate_landuse_min_zoom(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary", NEW.way_area);
     ELSE
         NEW.mz_is_landuse := NULL;
+        NEW.mz_landuse_min_zoom := NULL;
     END IF;
 
     NEW.mz_poi_min_zoom := mz_poi_min_zoom;

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -12,6 +12,7 @@
 
 SELECT
     '' AS name,
+    4::smallint AS min_zoom,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_50m_urban_areas
@@ -22,6 +23,7 @@ UNION ALL
 
 SELECT
   name,
+  (floor(mz_landuse_min_zoom))::smallint AS min_zoom,
   tags->'protect_class' AS protect_class,
   operator,
   way_area::bigint AS area,
@@ -34,12 +36,13 @@ FROM
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
-  AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
+  AND mz_landuse_min_zoom <= {{ zoom }}
 
 {% elif 6 <= zoom < 8 %}
 
 SELECT
     '' AS name,
+    4::smallint AS min_zoom, -- we show urban areas at 4, even if it's not from this table
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_10m_urban_areas
@@ -50,6 +53,7 @@ UNION ALL
 
 SELECT
   name,
+  (floor(mz_landuse_min_zoom))::smallint AS min_zoom,
   tags->'protect_class' AS protect_class,
   operator,
   way_area::bigint AS area,
@@ -62,12 +66,13 @@ FROM
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
-  AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
+  AND mz_landuse_min_zoom <= {{ zoom }}
 
 {% else %}
 
 SELECT
     name,
+    (least(16, floor(mz_landuse_min_zoom)))::smallint AS min_zoom,
     tags->'protect_class' AS protect_class,
     operator,
     way_area::bigint AS area,
@@ -84,7 +89,7 @@ WHERE
     mz_is_landuse = TRUE
     AND {{ bounds|bbox_filter('way') }}
     {% if zoom <= 15 %}
-    AND mz_one_pixel_zoom(way_area) <= {{ zoom }}
+    AND mz_landuse_min_zoom <= {{ zoom }}
     {% endif %}
 
 {% if zoom < 10 %}
@@ -93,6 +98,7 @@ UNION ALL
 -- "cross-fade" NE urban area polygons for a couple of zooms.
 SELECT
   '' AS name,
+  4::smallint AS min_zoom, -- we show urban areas at 4, even if it's not from this table
   {{ ne_landuse_cols('urban area') }},
   NULL AS sport,
   NULL AS religion,

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -12,7 +12,7 @@
 
 SELECT
     '' AS name,
-    4::smallint AS min_zoom,
+    4::real AS min_zoom,
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_50m_urban_areas
@@ -23,7 +23,7 @@ UNION ALL
 
 SELECT
   name,
-  (floor(mz_landuse_min_zoom))::smallint AS min_zoom,
+  mz_landuse_min_zoom AS min_zoom,
   tags->'protect_class' AS protect_class,
   operator,
   way_area::bigint AS area,
@@ -42,7 +42,7 @@ WHERE
 
 SELECT
     '' AS name,
-    4::smallint AS min_zoom, -- we show urban areas at 4, even if it's not from this table
+    4::real AS min_zoom, -- we show urban areas at 4, even if it's not from this table
     {{ ne_landuse_cols('urban area') }}
 FROM
     ne_10m_urban_areas
@@ -53,7 +53,7 @@ UNION ALL
 
 SELECT
   name,
-  (floor(mz_landuse_min_zoom))::smallint AS min_zoom,
+  mz_landuse_min_zoom AS min_zoom,
   tags->'protect_class' AS protect_class,
   operator,
   way_area::bigint AS area,
@@ -72,7 +72,7 @@ WHERE
 
 SELECT
     name,
-    (least(16, floor(mz_landuse_min_zoom)))::smallint AS min_zoom,
+    least(16, mz_landuse_min_zoom)::real AS min_zoom,
     tags->'protect_class' AS protect_class,
     operator,
     way_area::bigint AS area,
@@ -98,7 +98,7 @@ UNION ALL
 -- "cross-fade" NE urban area polygons for a couple of zooms.
 SELECT
   '' AS name,
-  4::smallint AS min_zoom, -- we show urban areas at 4, even if it's not from this table
+  4::real AS min_zoom, -- we show urban areas at 4, even if it's not from this table
   {{ ne_landuse_cols('urban area') }},
   NULL AS sport,
   NULL AS religion,


### PR DESCRIPTION
Re-using and renaming the old landuse labels function. This means we can tweak the function in future, not the query. Also adds `min_zoom` as a property which is exported and can be used for client-side priority and ordering.