### PR TITLE
Add ferry routes

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -7,7 +7,7 @@ BEGIN
 
 CREATE INDEX planet_osm_line_waterway_index ON planet_osm_line(waterway) WHERE waterway IS NOT NULL;
 CREATE INDEX planet_osm_line_admin_boundaries_index ON planet_osm_line(boundary) WHERE boundary='administrative';
-CREATE INDEX planet_osm_line_road_level_index ON planet_osm_line(mz_calculate_road_level(highway, railway, aeroway)) WHERE mz_calculate_road_level(highway, railway, aeroway) IS NOT NULL;
+CREATE INDEX planet_osm_line_road_level_index ON planet_osm_line(mz_calculate_road_level(highway, railway, aeroway, route, way)) WHERE mz_calculate_road_level(highway, railway, aeroway, route, way) IS NOT NULL;
 CREATE INDEX planet_osm_line_transit_level_index ON planet_osm_line(mz_calculate_transit_level(route)) WHERE mz_calculate_transit_level(route) IS NOT NULL;
 
 END $$;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -221,11 +221,13 @@ DECLARE
 BEGIN
   RETURN (
     CASE
-      WHEN way_length > 51356 THEN  9
-      WHEN way_length > 17215 THEN 10
-      WHEN way_length >  3400 THEN 11
-      WHEN way_length >  1700 THEN 12
-      ELSE                         13
+      -- this is about when the way is >= 2px in length
+      WHEN way_length > 1223 THEN  8
+      WHEN way_length >  611 THEN  9
+      WHEN way_length >  306 THEN 10
+      WHEN way_length >  153 THEN 11
+      WHEN way_length >   76 THEN 12
+      ELSE                        13
     END);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -214,7 +214,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text)
+CREATE OR REPLACE FUNCTION mz_calculate_ferry_level(way geometry)
+RETURNS SMALLINT AS $$
+DECLARE
+  way_length real := st_length(way);
+BEGIN
+  RETURN (
+    CASE
+      WHEN way_length > 51356 THEN  9
+      WHEN way_length > 17215 THEN 10
+      WHEN way_length >  3400 THEN 11
+      WHEN way_length >  1700 THEN 12
+      ELSE                         13
+    END);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text, route_val text, way geometry)
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
@@ -228,6 +244,7 @@ BEGIN
                 OR railway_val='rail') THEN 14
              WHEN (highway_val IN ('service', 'footpath', 'track', 'footway', 'steps', 'pedestrian', 'path', 'cycleway', 'living_street')
                 OR railway_val IN ('tram', 'light_rail', 'narrow_gauge', 'monorail')) THEN 15
+             WHEN route_val = 'ferry' THEN mz_calculate_ferry_level(way)
              ELSE NULL END
     );
 END;

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -62,8 +62,8 @@ WHERE
     {{ bounds|bbox_filter('way') }}
     AND mz_calculate_road_level(highway, railway, aeroway, route, way) <= {{ zoom }}
     -- the below is to filter out any relations-as-roads, since instead we are
-    -- projecting the network attribute onto the ways. it might need some finessing
-    -- if we're rendering other stuff from relations like cycle routes.
-    AND osm_id > 0
+    -- projecting the network attribute onto the ways. it needs some adjustment as
+    -- other features, in this case ferry routes, are routinely mapped as relations.
+    AND (osm_id > 0 OR route = 'ferry')
 
 {% endif %}

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -28,6 +28,7 @@ SELECT
     aeroway,
     bridge,
     highway,
+    tags->'ferry' AS ferry,
     layer,
     railway,
     tunnel,
@@ -52,13 +53,14 @@ SELECT
     tags->'descent' AS descent,
     tags->'roundtrip' AS roundtrip,
     tags->'route_name' AS route_name,
+    tags->'motor_vehicle' AS motor_vehicle,
     %#tags AS tags
 
 FROM planet_osm_line
 
 WHERE
     {{ bounds|bbox_filter('way') }}
-    AND mz_calculate_road_level(highway, railway, aeroway) <= {{ zoom }}
+    AND mz_calculate_road_level(highway, railway, aeroway, route, way) <= {{ zoom }}
     -- the below is to filter out any relations-as-roads, since instead we are
     -- projecting the network attribute onto the ways. it might need some finessing
     -- if we're rendering other stuff from relations like cycle routes.


### PR DESCRIPTION
Add ferry routes to the roads layer query and level index. A couple of potentially interesting extra properties are exposed:

* `ferry`: A small proportion of ferry routes have this set to `primary`, `secondary`, etc... mirroring the road network. Unfortunately, not very many do, and none in the Bay Area or New York City.
* `motor_vehicle`: When `yes`, it's a car ferry (the default seems to be passenger-only). This might be interesting or important to expose in the cartography.

Although the `ferry` property turned out to be less useful than originally hoped, it looks like the ferry route's length is a decent proxy for how important it is, as it doesn't tend to get segmentised like the road network. So I'm using that to tell what's "important", although the values may need a little tweaking.

Connects to #187. Requires mapzen/TileStache#64.

@rmarianski could you review, please?