### PR TITLE
Fix layer attribute on buildings

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -74,6 +74,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_remove
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
+      - TileStache.Goodies.VecTiles.transform.parse_layer_as_float
       - TileStache.Goodies.VecTiles.transform.road_kind
       - TileStache.Goodies.VecTiles.transform.road_classifier
       - TileStache.Goodies.VecTiles.transform.road_sort_key
@@ -94,6 +95,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_remove
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
+      - TileStache.Goodies.VecTiles.transform.parse_layer_as_float
       - TileStache.Goodies.VecTiles.transform.building_kind
       - TileStache.Goodies.VecTiles.transform.building_height
       - TileStache.Goodies.VecTiles.transform.building_min_height

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -12,7 +12,7 @@ SELECT
     "building:min_levels",
     height,
     min_height,
-    tags->'layer' AS layer,
+    layer,
     tags->'location' AS location,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
 {% if zoom >= 15 %}


### PR DESCRIPTION
The layer tag is promoted to an explicit column by osm2pgsql and this means that it removes it from the tags hstore. Changed the query to select it from the column instead.

Also added a new filter for parsing the layer as a number, as it is much more useful to be able to do numeric comparisons with it.

Requires mapzen/TileStache#65. Connects to #194.

@rmarianski could you review, please?