### PR TITLE
Set kind to `aboriginal_lands` for first nations state boundaries.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -127,6 +127,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.boundary_kind
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
+      - TileStache.Goodies.VecTiles.transform.boundary_trim_properties
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
   transit:
     template: transit.jinja2

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -61,6 +61,7 @@ SELECT
   name,
   NULL AS maritime_boundary,
   admin_level,
+  tags->'boundary:type' AS boundary_type,
   {% filter geometry %}way{% endfilter %} AS __geometry__,
   osm_id AS __id__,
   %#tags AS tags
@@ -77,6 +78,7 @@ SELECT
   NULL AS name,
   'yes' AS maritime_boundary,
   NULL AS admin_level,
+  NULL AS boundary_type,
   {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
   gid AS __id__,
   NULL AS tags


### PR DESCRIPTION
Connects to #284.

Selects the `boundary:type` type to disambiguate between `admin_level=4` boundaries [like this](http://www.openstreetmap.org/way/174550914) and the ones we're used to seeing. The kind filter is modified in mapzen/TileStache#66 to use this.

@rmarianski could you review, please?