### PR TITLE
Reduce boundary layer payload size.

### DIFF
--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -62,7 +62,11 @@ SELECT
   NULL AS maritime_boundary,
   admin_level,
   tags->'boundary:type' AS boundary_type,
-  {% filter geometry %}way{% endfilter %} AS __geometry__,
+  -- note that we force the RHR, which makes outers clockwise,
+  -- then take the boundary, then reverse and intersect with
+  -- the query bbox. this is needed because Shapely expects a
+  -- correctly-oriented outer to run counter-clockwise.
+  {% filter geometry %}{{ bounds|bbox_intersection('st_reverse(st_boundary(st_forcerhr(way)))') }}{% endfilter %} AS __geometry__,
   osm_id AS __id__,
   %#tags AS tags
 
@@ -71,6 +75,7 @@ FROM planet_osm_polygon
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND boundary='administrative'
+  AND admin_level IN ('2', '4' {% if zoom >= 10 %}, '8'{% endif %})
 
 UNION ALL
 
@@ -79,7 +84,7 @@ SELECT
   'yes' AS maritime_boundary,
   NULL AS admin_level,
   NULL AS boundary_type,
-  {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
+  {% filter geometry %}{{ bounds|bbox_intersection('the_geom') }}{% endfilter %} AS __geometry__,
   gid AS __id__,
   NULL AS tags
 

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -75,7 +75,7 @@ FROM planet_osm_polygon
 WHERE
   {{ bounds|bbox_filter('way') }}
   AND boundary='administrative'
-  AND admin_level IN ('2', '4' {% if zoom >= 10 %}, '8'{% endif %})
+  AND admin_level IN ('2', '4' {% if zoom >= 10 %}, '6', '8'{% endif %})
 
 UNION ALL
 


### PR DESCRIPTION
Orient admin polygons, take their boundary and clip the result in the query instead of later in Python. This reduces the amount of data that we send over the network for boundaries. Also, take only boundaries that we actually want to display (i.e: no county boundaries at zoom < 10). Finally, clip the buffered land polygons to the query box so that we're not sending the whole land boundary over the network. This would be better done up-front, to avoid the processing cost, but we can do that as a separate thing later.

Connects to #302, requires mapzen/TileStache#71 and mapzen/tilequeue#33.

For tile 8/40/98, the boundaries layer:
* Originally sent approximately 2,991,176 bytes over the wire.
* When reduced to only `admin_level`s 2 & 4 (at this zoom), approx. 1,658,088 bytes (45% fewer).
* When the boundaries were oriented and clipped on the server, approx. 374,446 bytes (77% fewer).
* When the buffered land was clipped on the server too, approx. 26,331 bytes (93% fewer).

For reference, when the `admin_level` filter was relaxed, but the clipping was kept, this went back up to 889,979 bytes (3280% more).

I've tested this on a few tiles, and it looks okay visually for some data on my machine, but it would be better to test in dev - especially that the orientation is still correct.

@rmarianski could you review, please?