### PR TITLE
Sort out generated features for landuse, buildings & POIs

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -161,6 +161,7 @@ BEGIN
       WHEN historic_val = 'landmark'         THEN LEAST(zoom + 1.76, 15)
       WHEN leisure_val  = 'marina'           THEN LEAST(zoom + 3.45, 17)
       WHEN amenity_val  = 'place_of_worship' THEN LEAST(2 * zoom - 9.55, 17)
+      WHEN amenity_val  = 'townhall'         THEN LEAST(zoom + 1.85, 16)
       WHEN (barrier_val IN ('gate')
             OR craft_val IN ('sawmill')
             OR highway_val IN ('gate', 'mini_roundabout')

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -269,7 +269,11 @@ CREATE OR REPLACE FUNCTION mz_calculate_is_building_or_part(
     building_val text, buildingpart_val text)
 RETURNS BOOLEAN AS $$
 BEGIN
-    RETURN (building_val IS NOT NULL OR buildingpart_val IS NOT NULL);
+    -- there are 12,000 uses of building=no, so we ought to take that into
+    -- account when figuring out if something is a building or not. also,
+    -- returning "kind=no" is a bit weird.
+    RETURN ((building_val IS NOT NULL AND building_val <> 'no') OR
+            (buildingpart_val IS NOT NULL AND buildingpart_val <> 'no'));
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -183,14 +183,15 @@ post_process:
       label_property_value: "yes"
   - fn: TileStache.Goodies.VecTiles.transform.generate_label_features
     params:
-      source_layer: buildings
-      label_property_name: label_placement
-      label_property_value: "yes"
-  - fn: TileStache.Goodies.VecTiles.transform.generate_label_features
-    params:
       source_layer: water
       label_property_name: label_placement
       label_property_value: "yes"
   - fn: TileStache.Goodies.VecTiles.transform.generate_address_points
     params:
       source_layer: buildings
+      start_zoom: 17
+  - fn: TileStache.Goodies.VecTiles.transform.generate_label_features
+    params:
+      source_layer: buildings
+      label_property_name: label_placement
+      label_property_value: "yes"

--- a/queries.yaml
+++ b/queries.yaml
@@ -113,6 +113,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
+      - TileStache.Goodies.VecTiles.transform.remove_zero_area
     sort: TileStache.Goodies.VecTiles.sort.pois
   boundaries:
     template: boundaries.jinja2

--- a/queries.yaml
+++ b/queries.yaml
@@ -191,3 +191,6 @@ post_process:
       source_layer: water
       label_property_name: label_placement
       label_property_value: "yes"
+  - fn: TileStache.Goodies.VecTiles.transform.generate_address_points
+    params:
+      source_layer: buildings

--- a/queries.yaml
+++ b/queries.yaml
@@ -195,3 +195,9 @@ post_process:
       source_layer: buildings
       label_property_name: label_placement
       label_property_value: "yes"
+  - fn: TileStache.Goodies.VecTiles.transform.drop_features_where
+    params:
+      source_layer: landuse
+      property_name: mz_is_building
+      drop_property: true
+      geom_types: [Polygon, MultiPolygon]

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -1,8 +1,12 @@
 SELECT
     -- drop name when the item is a POI - in that case the name
     -- probably refers to the POI. instead, we can use the house
-    -- name tag, if it has been set.
-    CASE WHEN mz_poi_min_zoom IS NULL THEN name
+    -- name tag, if it has been set. likewise for landuse areas
+    -- where we might want to label the landuse rather than the
+    -- building.
+    CASE WHEN mz_poi_min_zoom IS NULL AND
+              (mz_is_landuse IS NULL OR mz_is_landuse = FALSE)
+         THEN name
          ELSE "addr:housename"
     END AS name,
     way_area::bigint AS area,

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -1,13 +1,15 @@
 SELECT
-    name,
+    -- drop name when the item is a POI - in that case the name
+    -- probably refers to the POI. instead, we can use the house
+    -- name tag, if it has been set.
+    CASE WHEN mz_calculate_poi_level() IS NULL THEN name
+         ELSE "addr:housename" AS name,
     way_area::bigint AS area,
     osm_id AS __id__,
-    "building:part",
+    'openstreetmap.org' AS source,
     NULL AS kind,
     building,
-    amenity,
-    shop,
-    tourism,
+    "building:part",
     "building:levels",
     "building:min_levels",
     height,
@@ -15,17 +17,13 @@ SELECT
     layer,
     tags->'location' AS location,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
-{% if zoom >= 15 %}
     "roof:color" AS roof_color,
     "roof:material" AS roof_material,
     "roof:shape" AS roof_shape,
     "roof:height" AS roof_height,
     "roof:orientation" AS roof_orientation,
-{% endif %}
-{% if zoom >= 17 %}
     "addr:housenumber" AS addr_housenumber,
     "addr:street" AS addr_street,
-{% endif %}
     %#tags AS tags
 
 FROM
@@ -33,20 +31,22 @@ FROM
 
 WHERE
 
-{% if zoom < 15 %}
-    building IS NOT NULL
-  {% if zoom == 13 %}
-    AND way_area::bigint > 1600
-  {% elif zoom == 14 %}
-    AND way_area::bigint > 100
-  {% endif %}
-{% else %}
+    -- note: this is the first filter, as we use this to determine if
+    -- something should be a POI, a building or a landuse polygon, and
+    -- the logic needs to be consistent across all branches.
     mz_calculate_is_building_or_part(building, "building:part") = TRUE
-  {% if zoom == 15 %}
+{% if zoom < 15 %}
+    AND building IS NOT NULL AND building <> 'no'
+{% endif %}
+
+{% if zoom == 13 %}
+    AND way_area::bigint > 1600
+{% elif zoom == 14 %}
     AND way_area::bigint > 100
-  {% elif zoom == 16 %}
+{% elif zoom == 15 %}
+    AND way_area::bigint > 100
+{% elif zoom == 16 %}
     AND way_area::bigint > 25
-  {% endif %}
 {% endif %}
 
     AND {{ bounds|bbox_filter('way') }}
@@ -59,12 +59,10 @@ SELECT
     name,
     NULL AS area,
     osm_id AS __id__,
-    NULL AS "building:part",
+    'openstreetmap.org' AS source,
     'address' AS kind,
     NULL AS building,
-    NULL AS amenity,
-    NULL AS shop,
-    NULL AS tourism,
+    NULL AS "building:part",
     NULL AS "building:levels",
     NULL AS "building:min_levels",
     NULL AS height,

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -2,8 +2,9 @@ SELECT
     -- drop name when the item is a POI - in that case the name
     -- probably refers to the POI. instead, we can use the house
     -- name tag, if it has been set.
-    CASE WHEN mz_calculate_poi_level() IS NULL THEN name
-         ELSE "addr:housename" AS name,
+    CASE WHEN mz_poi_min_zoom IS NULL THEN name
+         ELSE "addr:housename"
+    END AS name,
     way_area::bigint AS area,
     osm_id AS __id__,
     'openstreetmap.org' AS source,

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -43,7 +43,8 @@ WHERE
 SELECT
     '' AS name,
     4::real AS min_zoom, -- we show urban areas at 4, even if it's not from this table
-    {{ ne_landuse_cols('urban area') }}
+    {{ ne_landuse_cols('urban area') }},
+    NULL AS mz_is_building
 FROM
     ne_10m_urban_areas
 WHERE
@@ -52,7 +53,7 @@ WHERE
 UNION ALL
 
 SELECT
-  name,
+  CASE WHEN mz_poi_min_zoom IS NULL THEN name ELSE NULL END AS name,
   mz_landuse_min_zoom AS min_zoom,
   tags->'protect_class' AS protect_class,
   operator,
@@ -60,13 +61,12 @@ SELECT
   mz_calculate_landuse_kind("landuse", "leisure", "natural", "highway", "aeroway", "amenity", "tourism", "man_made", "power", "boundary") AS kind,
   'openstreetmap.org' AS source,
   {% filter geometry %}way{% endfilter %} AS __geometry__,
-  osm_id AS __id__
+  osm_id AS __id__,
+  mz_calculate_is_building_or_part(building, "building:part") AS mz_is_building
 FROM
   planet_osm_polygon
 WHERE
   mz_is_landuse = TRUE
-  AND mz_calculate_is_building_or_part(building, "building:part") <> TRUE
-  AND mz_poi_min_zoom IS NULL
   AND {{ bounds|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_landuse_min_zoom <= {{ zoom }}
@@ -74,7 +74,7 @@ WHERE
 {% else %}
 
 SELECT
-    name,
+    CASE WHEN mz_poi_min_zoom IS NULL THEN name ELSE NULL END AS name,
     least(16, mz_landuse_min_zoom)::real AS min_zoom,
     tags->'protect_class' AS protect_class,
     operator,
@@ -85,13 +85,12 @@ SELECT
     osm_id AS __id__,
     sport,
     religion,
+    mz_calculate_is_building_or_part(building, "building:part") AS mz_is_building,
     %#tags AS tags
 FROM
     planet_osm_polygon
 WHERE
     mz_is_landuse = TRUE
-    AND mz_calculate_is_building_or_part(building, "building:part") <> TRUE
-    AND mz_poi_min_zoom IS NULL
     AND {{ bounds|bbox_filter('way') }}
     {% if zoom <= 15 %}
     AND mz_landuse_min_zoom <= {{ zoom }}
@@ -107,6 +106,7 @@ SELECT
   {{ ne_landuse_cols('urban area') }},
   NULL AS sport,
   NULL AS religion,
+  NULL AS mz_is_building,
   NULL AS tags
 FROM
   ne_10m_urban_areas

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -64,7 +64,10 @@ SELECT
 FROM
   planet_osm_polygon
 WHERE
-  {{ bounds|bbox_filter('way') }}
+  mz_is_landuse = TRUE
+  AND mz_calculate_is_building_or_part(building, "building:part") <> TRUE
+  AND mz_poi_min_zoom IS NULL
+  AND {{ bounds|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_landuse_min_zoom <= {{ zoom }}
 
@@ -87,6 +90,8 @@ FROM
     planet_osm_polygon
 WHERE
     mz_is_landuse = TRUE
+    AND mz_calculate_is_building_or_part(building, "building:part") <> TRUE
+    AND mz_poi_min_zoom IS NULL
     AND {{ bounds|bbox_filter('way') }}
     {% if zoom <= 15 %}
     AND mz_landuse_min_zoom <= {{ zoom }}

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -2,6 +2,7 @@ SELECT
     name,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
     osm_id AS __id__,
+    way_area AS area,
     cuisine,
     religion,
     sport,


### PR DESCRIPTION
* Added town hall POIs.
* Updated building selection criteria - turns out there's a lot of `building=no` things.
* Separated buildings, landuse and POIs so that the name should come through in only one of these layers. The polygon geometry is only duplicated between landuse and buildings when generating a landuse label, after which the landuse polygon is discarded. This gets rid of many duplicate labels.
* Added config to generate address points for (and from) buildings and drop landuse polygons which are duplicating buildings.

Connects to #201.

@rmarianski could you review, please?
