### PR TITLE
Too many subway stations

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -509,6 +509,9 @@ BEGIN
     WHERE (
       mz_rel_get_tag(n.tags, 'railway') IN ('station', 'stop') OR
       mz_rel_get_tag(n.tags, 'public_transport') = 'stop')
+    -- manually re-include the original station node, in case it's
+    -- not part of a public_transport=stop_area relation.
+    UNION SELECT station_node_id AS id
   );
 
   lines := ARRAY(

--- a/queries.yaml
+++ b/queries.yaml
@@ -230,10 +230,9 @@ post_process:
     params:
       source_layer: pois
       end_zoom: 16
-  - fn: TileStache.Goodies.VecTiles.transform.keep_n_features
+  - fn: TileStache.Goodies.VecTiles.transform.rank_features
     params:
       source_layer: pois
-      end_zoom: 16
       items_matching:
         kind: station
-      max_items: 8
+      rank_key: rank

--- a/queries.yaml
+++ b/queries.yaml
@@ -226,3 +226,14 @@ post_process:
       property_name: mz_is_building
       drop_property: true
       geom_types: [Polygon, MultiPolygon]
+  - fn: TileStache.Goodies.VecTiles.transform.normalize_and_merge_duplicate_stations
+    params:
+      source_layer: pois
+      end_zoom: 16
+  - fn: TileStache.Goodies.VecTiles.transform.keep_n_features
+    params:
+      source_layer: pois
+      end_zoom: 16
+      items_matching:
+        kind: station
+      max_items: 8

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -6,6 +6,7 @@ SELECT
     cuisine,
     religion,
     sport,
+    subway_lines,
     %#tags AS tags,
     COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic",
              "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop",
@@ -18,6 +19,13 @@ FROM (
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
+    -- note: the mz_calculate_subway_lines function is pretty expensive,
+    -- so we only want to calculate it when we actually need the result.
+    CASE
+      WHEN railway='station' AND osm_id > 0
+        THEN mz_calculate_subway_lines(osm_id)
+      ELSE NULL::text[]
+    END AS subway_lines,
     tags
 
   FROM
@@ -34,6 +42,7 @@ UNION ALL
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
+    NULL AS subway_lines,
     tags
 
   FROM


### PR DESCRIPTION
In some places with dense public transit infrastructure (e.g: NYC) we are displaying too many stations at zoom 13/14 and need some way to select which are the important ones.

This PR adds a query for pulling out the lines which a station is connected to by looking at the relations and ways tables. This isn't exactly fast, but there aren't very many stations in the database (fewer than 5,000 in North America), so it shouldn't have too much impact if we only run it for stations.

This PR also runs a couple of new post-processing functions to merge and rank station POIs to try and get close to some useful measure of the importance of a station - which is often an extended object with many branches, platforms and lines.

Connects to #268, requires mapzen/TileStache#75.

@rmarianski could you review, please?
