### PR TITLE
Add WOF neighbourhoods to `places` layer

### DIFF
--- a/data/perform-sql-updates.sh
+++ b/data/perform-sql-updates.sh
@@ -11,6 +11,7 @@ psql $@ -f apply-updates-non-planet-tables.sql &
 psql $@ -f apply-planet_osm_polygon.sql &
 psql $@ -f apply-planet_osm_line.sql &
 psql $@ -f apply-planet_osm_point.sql &
+psql $@ -f wof-schema.sql &
 wait
 echo "done."
 

--- a/data/wof-schema.sql
+++ b/data/wof-schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE wof_neighbourhood (
+  wof_id BIGINT UNIQUE,
+  name TEXT NOT NULL
+);
+
+SELECT AddGeometryColumn ('wof_neighbourhood', 'label_position', 900913, 'POINT', 2);
+
+CREATE INDEX wof_neighbourhood_label_position_index ON wof_neighbourhood USING GIST(label_position);

--- a/queries/places.jinja2
+++ b/queries/places.jinja2
@@ -53,3 +53,27 @@ WHERE
         {% if zoom >= 13 %}, 'locality', 'isolated_dwelling', 'farm'{% endif %}
     )
     AND {{ bounds|bbox_filter('way') }}
+
+{% if zoom >= 12 %}
+UNION ALL
+
+SELECT
+    name,
+    'neighbourhood' AS kind,
+    'whosonfirst' AS source,
+    {% filter geometry %}label_position{% endfilter %} AS __geometry__,
+    wof_id AS __id__,
+
+    NULL AS admin_level,
+    NULL AS scalerank,
+    NULL AS labelrank,
+    NULL AS population,
+    NULL AS capital,
+    NULL AS state_capital,
+    NULL AS tags
+
+FROM wof_neighbourhood
+
+WHERE {{ bounds|bbox_filter('label_position') }}
+
+{% endif %}


### PR DESCRIPTION
Refs #147. Related to https://github.com/mapzen/tilequeue/pull/36.

I spelled it "neighbourhoods" throughout to be consistent with OSM and WOF. This is also the `kind` that I used for these features.

I made the source value `whosonfirst`. Sometimes we use a url and sometimes we don't. Should we try to make it more consistent throughout all layers?

@nvkelso, @zerebubuth: could you review please?