### PR TITLE
Enable snapping tolerance for exterior boundaries post-processor.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -160,6 +160,7 @@ post_process:
         id: true
         source: true
         boundary: "yes"
+      snap_tolerance: 0.125
   - fn: TileStache.Goodies.VecTiles.transform.overlap
     params:
       base_layer: buildings


### PR DESCRIPTION
Requires mapzen/TileStache#76, connects to #303.

Config change to enable snapping coordinates to grid before deriving the boundary.

@rmarianski could you review, please?
