### PR TITLE
Add service tag to roads query

### DIFF
--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -54,6 +54,7 @@ SELECT
     tags->'roundtrip' AS roundtrip,
     tags->'route_name' AS route_name,
     tags->'motor_vehicle' AS motor_vehicle,
+    service,
     %#tags AS tags
 
 FROM planet_osm_line


### PR DESCRIPTION
This gives a second level of information for highway and railway features, and allows us to distinguish some kinds of secondary railways.

Connects to #308.

@rmarianski could you review, please?