### PR TITLE
Call the rank property tile_rank instead.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -235,4 +235,4 @@ post_process:
       source_layer: pois
       items_matching:
         kind: station
-      rank_key: rank
+      rank_key: tile_rank


### PR DESCRIPTION
As per https://github.com/mapzen/vector-datasource/issues/268#issuecomment-150382161.

Connects to #268.

@rmarianski could you review, please?