### PR TITLE
Add city walls from z14 onwards.

### DIFF
--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -104,7 +104,9 @@ SELECT
   NULL AS maritime_boundary,
   NULL AS admin_level,
   NULL AS boundary_type,
-  'city_wall' AS kind,
+  CASE WHEN barrier='retaining_wall' THEN 'retaining_wall'
+       ELSE 'city_wall'
+  END AS kind,
   {% filter geometry %}way{% endfilter %} AS __geometry__,
   osm_id AS __id__,
   %#tags AS tags
@@ -114,7 +116,12 @@ FROM
 
 WHERE
   {{ bounds|bbox_filter('way') }}
-  AND (barrier='city_wall' OR historic='citywalls')
+  AND (
+    barrier='city_wall' OR historic='citywalls'
+{% if zoom >= 15 %}
+    OR barrier='retaining_wall'
+{% endif %}
+  )
 
 {% endif %}
 

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -95,7 +95,7 @@ FROM buffered_land
 WHERE
   {{ bounds|bbox_filter('the_geom') }}
 
-{% if zoom >= 14 %}
+{% if zoom >= 12 %}
 
 UNION ALL
 

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -62,6 +62,7 @@ SELECT
   NULL AS maritime_boundary,
   admin_level,
   tags->'boundary:type' AS boundary_type,
+  NULL AS kind,
   -- note that we force the RHR, which makes outers clockwise,
   -- then take the boundary, then reverse and intersect with
   -- the query bbox. this is needed because Shapely expects a
@@ -84,6 +85,7 @@ SELECT
   'yes' AS maritime_boundary,
   NULL AS admin_level,
   NULL AS boundary_type,
+  NULL AS kind,
   {% filter geometry %}{{ bounds|bbox_intersection('the_geom') }}{% endfilter %} AS __geometry__,
   gid AS __id__,
   NULL AS tags
@@ -92,5 +94,28 @@ FROM buffered_land
 
 WHERE
   {{ bounds|bbox_filter('the_geom') }}
+
+{% if zoom >= 14 %}
+
+UNION ALL
+
+SELECT
+  name,
+  NULL AS maritime_boundary,
+  NULL AS admin_level,
+  NULL AS boundary_type,
+  'city_wall' AS kind,
+  {% filter geometry %}way{% endfilter %} AS __geometry__,
+  osm_id AS __id__,
+  %#tags AS tags
+
+FROM
+  planet_osm_line
+
+WHERE
+  {{ bounds|bbox_filter('way') }}
+  AND (barrier='city_wall' OR historic='citywalls')
+
+{% endif %}
 
 {% endif %}


### PR DESCRIPTION
Pulls in both `barrier=city_wall` and `historic=citywalls` from zoom 14 onwards, same as OSM carto.

Connects to #188.

@rmarianski could you review, please?