### PR TITLE
Updated road (and road-like features) zoom levels.

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -9,7 +9,7 @@ ALTER TABLE planet_osm_line ADD COLUMN mz_road_level SMALLINT;
 ALTER TABLE planet_osm_line ADD COLUMN mz_transit_level SMALLINT;
 
 UPDATE planet_osm_line
-  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, way)
+  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, service, way)
   WHERE mz_calculate_road_level(highway, railway, aeroway, route, way) IS NOT NULL;
 
 UPDATE planet_osm_line

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -39,7 +39,7 @@ CREATE TRIGGER mz_trigger_point BEFORE INSERT OR UPDATE ON planet_osm_point FOR 
 CREATE OR REPLACE FUNCTION mz_trigger_function_line()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.mz_road_level := mz_calculate_road_level(NEW.highway, NEW.railway, NEW.aeroway, NEW.route, NEW.way);
+    NEW.mz_road_level := mz_calculate_road_level(NEW.highway, NEW.railway, NEW.aeroway, NEW.route, NEW.service, NEW.way);
     NEW.mz_transit_level := mz_calculate_transit_level(NEW.route);
     RETURN NEW;
 END;


### PR DESCRIPTION
Refactored `mz_calculate_road_level` into separate sections for roads, railways, aeroways and ferries to make it more readable and maintainable. Made changes as described in #332 to min zooms for the features.

Note that, due to the changes on the triggers, this needs a migration. I ran `data/functions.sql`, then:

```SQL
DROP TRIGGER mz_trigger_line ON planet_osm_line;

UPDATE planet_osm_line SET
  mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, service, way)
  WHERE
    highway IS NOT NULL OR
    railway IS NOT NULL OR
    aeroway IS NOT NULL OR
    route IS NOT NULL OR
    service IS NOT NULL;
    
CREATE OR REPLACE FUNCTION mz_trigger_function_line()
RETURNS TRIGGER AS $$
BEGIN
    NEW.mz_road_level := mz_calculate_road_level(NEW.highway, NEW.railway, NEW.aeroway, NEW.route, NEW.service, NEW.way);
    NEW.mz_transit_level := mz_calculate_transit_level(NEW.route);
    RETURN NEW;
END;
$$ LANGUAGE plpgsql VOLATILE;

CREATE TRIGGER mz_trigger_line BEFORE INSERT OR UPDATE ON planet_osm_line FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_line();

DROP FUNCTION mz_calculate_road_level(text, text, text, text, geometry);
```

Connects to #332.

@rmarianski could you review, please?
