### PR TITLE
Water boundaries should carry the area tag from their parent object.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -160,6 +160,7 @@ post_process:
         id: true
         source: true
         boundary: "yes"
+        area: true
       snap_tolerance: 0.125
   - fn: TileStache.Goodies.VecTiles.transform.overlap
     params:


### PR DESCRIPTION
Connects to #331.

Now I get this in the tile:

```json
[
  {
    "type": "Polygon",
    "properties": {
      "id": 16752862,
      "source": "openstreetmap.org",
      "kind": "water",
      "name": "Lake Merced",
      "area": 512961
    },
    "arcs": [
      [
        14
      ]
    ]
  },
  {
    "type": "LineString",
    "properties": {
      "id": 16752862,
      "source": "openstreetmap.org",
      "kind": "water",
      "boundary": "yes",
      "area": 512961
    },
    "arcs": [
      15
    ]
  }
]
```

@rmarianski could you review, please?