### PR TITLE
Filter buildings by volume, if possible.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -145,6 +145,15 @@ layers:
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
     sort: TileStache.Goodies.VecTiles.sort.transit
 post_process:
+  - fn: TileStache.Goodies.VecTiles.transform.numeric_min_filter
+    params:
+      source_layer: buildings
+      mode: any
+      filters:
+        13: { area: 1600, volume: 300000 }
+        14: { area:  100, volume: 200000 }
+        15: { area:  100, volume: 100000 }
+        16: { area:   25, volume:  50000 }
   - fn: TileStache.Goodies.VecTiles.transform.intercut
     params:
       base_layer: roads

--- a/queries.yaml
+++ b/queries.yaml
@@ -99,6 +99,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.building_kind
       - TileStache.Goodies.VecTiles.transform.building_height
       - TileStache.Goodies.VecTiles.transform.building_min_height
+      - TileStache.Goodies.VecTiles.transform.synthesize_volume
       - TileStache.Goodies.VecTiles.transform.building_trim_properties
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
     sort: TileStache.Goodies.VecTiles.sort.buildings

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -44,14 +44,14 @@ WHERE
     AND building IS NOT NULL AND building <> 'no'
 {% endif %}
 
-{% if zoom == 13 %}
-    AND way_area::bigint > 1600
+{% if   zoom == 13 %}
+   AND mz_building_filter(tags->'building:height', "building:levels", way_area, 300000, 1600)
 {% elif zoom == 14 %}
-    AND way_area::bigint > 100
+   AND mz_building_filter(tags->'building:height', "building:levels", way_area, 200000,  100)
 {% elif zoom == 15 %}
-    AND way_area::bigint > 100
+   AND mz_building_filter(tags->'building:height', "building:levels", way_area, 100000,  100)
 {% elif zoom == 16 %}
-    AND way_area::bigint > 25
+   AND mz_building_filter(tags->'building:height', "building:levels", way_area,  50000,   25)
 {% endif %}
 
     AND {{ bounds|bbox_filter('way') }}


### PR DESCRIPTION
Complexify the building filter logic and extract some of it to a separate function for maintainability. This allows us to do an approximate filter on building volume, without proper tag parsing. That can be done in the transform stage, in Python, so that the client can do a proper, final filter before display.

Connects to #212.

@rmarianski could you review, please?