### PR TITLE
Add aerialways to roads layer.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -287,7 +287,21 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text, route_val text, service_val text, way geometry)
+CREATE OR REPLACE FUNCTION mz_calculate_aerialway_level(aerialway_val text)
+RETURNS SMALLINT AS $$
+BEGIN
+  RETURN CASE
+    WHEN aerialway_val IN ('gondola', 'cable_car')                   THEN 12
+    WHEN aerialway_val IN ('chair_lift')                             THEN 13
+    WHEN aerialway_val IN ('drag_lift', 'platter', 't-bar', 'goods',
+         'magic_carpet', 'rope_tow', 'yes', 'zip_line', 'j-bar',
+         'unknown', 'mixed_lift', 'canopy', 'cableway')              THEN 15
+    ELSE NULL
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION mz_calculate_road_level(highway_val text, railway_val text, aeroway_val text, route_val text, service_val text, aerialway_val text, way geometry)
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN LEAST(
@@ -302,6 +316,9 @@ BEGIN
         ELSE NULL END,
       CASE WHEN route_val = 'ferry'
         THEN mz_calculate_ferry_level(way)
+        ELSE NULL END,
+      CASE WHEN aerialway_val IS NOT NULL
+        THEN mz_calculate_aerialway_level(aerialway_val)
         ELSE NULL END);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;

--- a/queries.yaml
+++ b/queries.yaml
@@ -81,6 +81,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.road_oneway
       - TileStache.Goodies.VecTiles.transform.road_abbreviate_name
       - TileStache.Goodies.VecTiles.transform.route_name
+      - TileStache.Goodies.VecTiles.transform.normalize_aerialways
       - TileStache.Goodies.VecTiles.transform.road_trim_properties
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
     sort: TileStache.Goodies.VecTiles.sort.roads

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -26,6 +26,7 @@ SELECT
     'openstreetmap' AS source,
     name,
     aeroway,
+    aerialway,
     bridge,
     highway,
     tags->'ferry' AS ferry,


### PR DESCRIPTION
Adds aerialways to the roads query. This means altering the roads level, again. The migration I used was to update the functions, then run:

```SQL
DROP TRIGGER mz_trigger_line ON planet_osm_line;

UPDATE planet_osm_line SET
  mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, service, aerialway, way)
  WHERE
    aerialway IS NOT NULL;
    
CREATE OR REPLACE FUNCTION mz_trigger_function_line()
RETURNS TRIGGER AS $$
BEGIN
    NEW.mz_road_level := mz_calculate_road_level(NEW.highway, NEW.railway, NEW.aeroway, NEW.route, NEW.service, NEW.aerialway, NEW.way);
    NEW.mz_transit_level := mz_calculate_transit_level(NEW.route);
    RETURN NEW;
END;
$$ LANGUAGE plpgsql VOLATILE;

CREATE TRIGGER mz_trigger_line BEFORE INSERT OR UPDATE ON planet_osm_line FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_line();

DROP FUNCTION mz_calculate_road_level(text, text, text, text, text, geometry);
```

Requires mapzen/TileStache/pull/82. Connects to #189.

@rmarianski could you review, please?
