### PR TITLE
Updates for transit routes

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -534,12 +534,12 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 
--- calculate the list of refs (or names) of subway lines that a
--- particular station is part of. this ends up being a very
+-- calculate the list of refs (or names) of transit routes that
+-- a particular station is part of. this ends up being a very
 -- complex function because it's bouncing around between the
 -- nodes, ways and relations to calculate membership of various
 -- sets.
-CREATE OR REPLACE FUNCTION mz_calculate_subway_lines(
+CREATE OR REPLACE FUNCTION mz_calculate_transit_routes(
   station_node_id BIGINT)
 RETURNS text[] AS $$
 DECLARE
@@ -555,8 +555,8 @@ DECLARE
 
   -- IDs of ways which contain any of the stations and stops.
   -- these are included because sometimes the stop node isn't
-  -- directly included in the subway route relation, only the
-  -- way representing the track itself.
+  -- directly included in the route relation, only the way
+  -- representing the track itself.
   lines              bigint[];
 
 BEGIN

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -6,7 +6,7 @@ SELECT
     cuisine,
     religion,
     sport,
-    subway_lines,
+    transit_routes,
     %#tags AS tags,
     COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic",
              "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop",
@@ -19,13 +19,13 @@ FROM (
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
-    -- note: the mz_calculate_subway_lines function is pretty expensive,
+    -- note: the mz_calculate_transit_routes function is pretty expensive,
     -- so we only want to calculate it when we actually need the result.
     CASE
       WHEN railway='station' AND osm_id > 0
-        THEN mz_calculate_subway_lines(osm_id)
+        THEN mz_calculate_transit_routes(osm_id)
       ELSE NULL::text[]
-    END AS subway_lines,
+    END AS transit_routes,
     tags
 
   FROM
@@ -42,7 +42,7 @@ UNION ALL
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
-    NULL AS subway_lines,
+    NULL AS transit_routes,
     tags
 
   FROM


### PR DESCRIPTION
Update query function to include light rail, tram and main line rail routes. Split the `ref`, as this seems to be sometimes comma-delimited. Renamed `subway_lines` to `transit_routes`, as it's collecting more than just subway lines now.

Note that the name of the function changed, so the migration should run `functions.sql` and then:

```SQL
DROP FUNCTION mz_calculate_subway_lines(bigint);
```

Connects to #268.

@rmarianski could you review, please?