### PR TITLE
Use representative point for POIs, not centroid.

### DIFF
--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -15,7 +15,6 @@ CREATE INDEX planet_osm_polygon_is_water_index ON planet_osm_polygon(mz_calculat
 
 -- update polygon table to add centroids
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_is_landuse BOOLEAN;
-ALTER TABLE planet_osm_polygon ADD COLUMN mz_centroid GEOMETRY;
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_poi_min_zoom REAL;
 ALTER TABLE planet_osm_polygon ADD COLUMN mz_landuse_min_zoom REAL;
 
@@ -30,15 +29,7 @@ UPDATE planet_osm_polygon SET
     mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", way_area)
     WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway") IS NOT NULL;
 
--- at the moment we only add centroids to landuse or POI features
-UPDATE planet_osm_polygon SET
-    mz_centroid = ST_Centroid(way)
-    WHERE mz_is_landuse = TRUE
-       OR mz_poi_min_zoom IS NOT NULL;
-
-
 CREATE INDEX planet_osm_polygon_is_landuse_col_index ON planet_osm_polygon(mz_is_landuse) WHERE mz_is_landuse=TRUE;
-CREATE INDEX planet_osm_polygon_centroid_landuse_index ON planet_osm_polygon USING gist(mz_centroid) WHERE mz_is_landuse=TRUE;
 
 CREATE INDEX planet_osm_polygon_landuse_geom_9_index ON planet_osm_polygon USING gist(way) WHERE mz_is_landuse=TRUE AND mz_landuse_min_zoom <= 9;
 CREATE INDEX planet_osm_polygon_landuse_geom_12_index ON planet_osm_polygon USING gist(way) WHERE mz_is_landuse=TRUE AND mz_landuse_min_zoom <= 12;

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -14,12 +14,6 @@ BEGIN
 
     NEW.mz_poi_min_zoom := mz_poi_min_zoom;
 
-    IF mz_is_landuse OR mz_poi_min_zoom IS NOT NULL THEN
-        NEW.mz_centroid := ST_Centroid(NEW.way);
-    ELSE
-        NEW.mz_centroid := NULL;
-    END IF;
-
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/queries.yaml
+++ b/queries.yaml
@@ -107,7 +107,7 @@ layers:
   pois:
     template: pois.jinja2
     start_zoom: 9
-    geometry_types: [Point, MultiPoint]
+    geometry_types: [Point, MultiPoint, Polygon, MultiPolygon]
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
@@ -116,6 +116,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
       - TileStache.Goodies.VecTiles.transform.remove_zero_area
+      - TileStache.Goodies.VecTiles.transform.make_representative_point
     sort: TileStache.Goodies.VecTiles.sort.pois
   boundaries:
     template: boundaries.jinja2

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -38,7 +38,7 @@ FROM (
 UNION ALL
 
   SELECT
-    name, mz_centroid AS way, way_area, mz_poi_min_zoom AS min_zoom,
+    name, way, way_area, mz_poi_min_zoom AS min_zoom,
     osm_id,
     cuisine, religion, sport,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,


### PR DESCRIPTION
Remove references to centroid column. Instead, turn shape into representative point in the filter chain.

Requires mapzen/TileStache#88. Connects to #266. Refs [this issue](https://github.com/mapzen/vector-datasource/issues/266#issuecomment-152471241).

This requires a migration to remove the `mz_centroid` column and related indexes / triggers. This is what I used locally:

```SQL
DROP INDEX planet_osm_polygon_centroid_landuse_index;

BEGIN;

DROP TRIGGER mz_trigger_polygon ON planet_osm_polygon;

ALTER TABLE planet_osm_polygon DROP COLUMN mz_centroid;

CREATE OR REPLACE FUNCTION mz_trigger_function_polygon()
RETURNS TRIGGER AS $$
DECLARE
    mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary");
    mz_poi_min_zoom REAL = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW.way_area);
BEGIN
    IF mz_is_landuse THEN
        NEW.mz_is_landuse := TRUE;
        NEW.mz_landuse_min_zoom := mz_calculate_landuse_min_zoom(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary", NEW.way_area);
    ELSE
        NEW.mz_is_landuse := NULL;
        NEW.mz_landuse_min_zoom := NULL;
    END IF;

    NEW.mz_poi_min_zoom := mz_poi_min_zoom;

    RETURN NEW;
END;
$$ LANGUAGE plpgsql VOLATILE;

CREATE TRIGGER mz_trigger_polygon BEFORE INSERT OR UPDATE ON planet_osm_polygon FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_polygon();

COMMIT;
```

@rmarianski could you review, please?