### PR TITLE
Fix transit routes in London & Paris

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -577,7 +577,7 @@ BEGIN
     ON r.node_id = n.id
     WHERE (
       mz_rel_get_tag(n.tags, 'railway') IN ('station', 'stop') OR
-      mz_rel_get_tag(n.tags, 'public_transport') = 'stop')
+      mz_rel_get_tag(n.tags, 'public_transport') IN ('stop', 'stop_position'))
     -- manually re-include the original station node, in case it's
     -- not part of a public_transport=stop_area relation.
     UNION SELECT station_node_id AS id


### PR DESCRIPTION
It seems that `public_transport=stop_position` is a widely-used variant for the node representing the stop, but it was previously only looking for `public_transport=stop` (and a couple of other tags). This was preventing it from picking up any transit routes for many stops.

Before this change, in London there were 209 stops without any routes (of 533 total). In Paris, 101 empty of 766 total. In Berlin, 44 empty of 289 total. In Chicago, 44 empty of 77 total. In NYC, 47 empty of 663 total. (Note that these areas are what was in the bounding box I chose, not any meaningful boundary of the city, so don't read too much into them).

After this change, In London 186 empty of 533 total. In Paris, 54 empty of 766 total. In Berlin, 39 empty of 289 total. In Chicago, 11 empty of 77 total. In NYC, 44 empty of 663 total.

The biggest gains were in Paris and Chicago, although some of the 23 improved stations in London were quite prominent (Euston, Paddington). After investigating a few of the stations in London still without `transit_routes`, it seems like (as with BART stations in SF) the issue is that there's no data to connect the railway station node to the route relations which give us the transit information.

Connects to #376.

@rmarianski could you review, please?

