### PR TITLE
Add aerialway argument to mz_calculate_road_level in line table update trigger

### DIFF
--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -33,8 +33,8 @@ CREATE TRIGGER mz_trigger_point BEFORE INSERT OR UPDATE ON planet_osm_point FOR 
 CREATE OR REPLACE FUNCTION mz_trigger_function_line()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.mz_road_level := mz_calculate_road_level(NEW.highway, NEW.railway, NEW.aeroway, NEW.route, NEW.service, NEW.way);
-    NEW.mz_transit_level := mz_calculate_transit_level(NEW.route);
+    NEW.mz_road_level := mz_calculate_road_level(NEW."highway", NEW."railway", NEW."aeroway", NEW."route", NEW."service", NEW."aerialway", NEW."way");
+    NEW.mz_transit_level := mz_calculate_transit_level(NEW."route");
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This makes the trigger declaration consistent with the arity change to mz_calculate_road_level in #341. I've also added "'s to the column references for the sake of stylistic consistency.