### PR TITLE
Query for mz_is_landuse=TRUE to use existing index

### DIFF
--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -34,7 +34,8 @@ SELECT
 FROM
   planet_osm_polygon
 WHERE
-  {{ bounds|bbox_filter('way') }}
+  mz_is_landuse = TRUE
+  AND {{ bounds|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_landuse_min_zoom <= {{ zoom }}
 


### PR DESCRIPTION
Refs https://github.com/mapzen/vector-datasource/issues/408

This adds a filter condition to the low zoom landuse queries to allow an existing index to be used.

It seems like the `mz_is_landuse` condition is redundant with `mz_landuse_min_zoom` though, at least in the landuse queries. If so, we could consider removing the `mz_is_landuse` condition from both the queries and the index.

@zerebubuth: could you review please?