### PR TITLE
Fixed a typo in 'parking_aisle'

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -268,7 +268,7 @@ BEGIN
     WHEN highway_val = 'service' THEN CASE
       WHEN service_val IS NULL                                                THEN 14
       WHEN service_val = 'alley'                                              THEN 13
-      WHEN service_val IN ('driveway', 'parking aisle', 'drive-through')      THEN 15
+      WHEN service_val IN ('driveway', 'parking_aisle', 'drive-through')      THEN 15
       ELSE NULL
     END
     ELSE NULL


### PR DESCRIPTION
The zoom selection statement had a space where it should have had an underscore. I checked the other values, and they seem to be correct (`drive-through` is most commonly used with a hyphen).

Connects to #412.

@rmarianski could you review, please?

NOTE: This needs a migration. Something like `UPDATE planet_osm_line SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "way") WHERE highway='service' AND service='parking_aisle'` should work.