### PR TITLE
Add highway exit points to the roads layer.

### DIFF
--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -18,6 +18,8 @@ CREATE INDEX planet_osm_point_min_zoom_way_9_index ON planet_osm_point USING gis
 CREATE INDEX planet_osm_point_min_zoom_way_12_index ON planet_osm_point USING gist(way) WHERE mz_poi_min_zoom <= 12;
 CREATE INDEX planet_osm_point_min_zoom_way_15_index ON planet_osm_point USING gist(way) WHERE mz_poi_min_zoom <= 15;
 
+CREATE INDEX planet_osm_point_motorway_junction_index ON planet_osm_point USING gist(way) WHERE highway='motorway_junction';
+
 END $$;
 
 ANALYZE planet_osm_point;

--- a/queries.yaml
+++ b/queries.yaml
@@ -67,7 +67,7 @@ layers:
   roads:
     template: roads.jinja2
     start_zoom: 5
-    geometry_types: [LineString, MultiLineString]
+    geometry_types: [Point, MultiPoint, LineString, MultiLineString]
     simplify_start: 8
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -64,6 +64,7 @@ SELECT
     NULL AS ski,
     NULL AS snowshoe,
     NULL AS symbol,
+    NULL AS exit_to,
     %#tags AS tags
 
 FROM planet_osm_line
@@ -119,6 +120,7 @@ SELECT
     tags->'ski' AS ski,
     tags->'snowshoe' AS snowshoe,
     tags->'symbol' AS symbol,
+    NULL AS exit_to,
     %#tags AS tags
 
 FROM planet_osm_line
@@ -129,6 +131,55 @@ WHERE
     AND tags->'piste:type' IN ('nordic', 'downhill', 'sleigh', 'skitour',
         'hike', 'sled', 'yes', 'snow_park', 'playground', 'ski_jump')
     AND (osm_id > 0 OR route = 'piste')
+
+UNION ALL
+
+SELECT
+    osm_id AS __id__,
+    {% filter geometry %}way{% endfilter %} AS __geometry__,
+    'openstreetmap' AS source,
+    name,
+    NULL AS aeroway,
+    NULL AS aerialway,
+    NULL AS bridge,
+    highway,
+    NULL AS ferry,
+    layer,
+    NULL AS railway,
+    NULL AS tunnel,
+    NULL AS oneway,
+    ref,
+    operator,
+    route,
+    tags->'type' AS type,
+    tags->'colour' AS colour,
+    NULL AS network,
+    tags->'state' AS state,
+    tags->'symbol' AS symbol,
+    tags->'description' AS description,
+    NULL AS distance,
+    NULL AS ascent,
+    NULL AS descent,
+    NULL AS roundtrip,
+    NULL AS route_name,
+    NULL AS motor_vehicle,
+    NULL AS service,
+    NULL AS piste_type,
+    NULL AS piste_difficulty,
+    NULL AS piste_grooming,
+    NULL AS piste_name,
+    NULL AS piste_abandoned,
+    NULL AS ski,
+    NULL AS snowshoe,
+    NULL AS symbol,
+    tags->'exit_to' AS exit_to,
+    %#tags AS tags
+
+FROM planet_osm_point
+
+WHERE
+    {{ bounds|bbox_filter('way') }}
+    AND highway = 'motorway_junction'
 
 {% endif %}
 


### PR DESCRIPTION
This adds the points and an index over them.

**Note** that these are the first points to be added to the road layer, so might cause issues for anyone who isn't expecting them.

Also requires a migration to create the index: `CREATE INDEX planet_osm_point_motorway_junction_index ON planet_osm_point USING gist(way) WHERE highway='motorway_junction';`

Connects to #160.

@rmarianski could you review, please?