### PR TITLE
Added platforms to the transit layer.

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -35,6 +35,8 @@ CREATE INDEX planet_osm_line_waterway_geom_index ON planet_osm_line USING gist(w
 
 CREATE INDEX planet_osm_line_piste_geom_index ON planet_osm_line USING gist(way) WHERE tags ? 'piste:type';
 
+CREATE INDEX planet_osm_line_railway_platform_index ON planet_osm_line USING gist(way) WHERE railway='platform';
+
 END $$;
 
 ANALYZE planet_osm_line;

--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -41,6 +41,8 @@ CREATE INDEX planet_osm_polygon_landuse_boundary_geom_8_index ON planet_osm_poly
 
 CREATE INDEX planet_osm_polygon_water_geom_index ON planet_osm_polygon USING gist(way) WHERE mz_calculate_is_water("waterway", "natural", "landuse") = TRUE;
 
+CREATE INDEX planet_osm_polygon_railway_platform_index ON planet_osm_polygon USING gist(way) WHERE railway='platform';
+
 END $$;
 
 ANALYZE planet_osm_polygon;

--- a/queries.yaml
+++ b/queries.yaml
@@ -137,7 +137,7 @@ layers:
   transit:
     template: transit.jinja2
     start_zoom: 6
-    geometry_types: [LineString, MultiLineString]
+    geometry_types: [LineString, MultiLineString, Polygon, MultiPolygon]
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
@@ -145,6 +145,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation
       - TileStache.Goodies.VecTiles.transform.route_name
+      - TileStache.Goodies.VecTiles.transform.parse_layer_as_float
       - TileStache.Goodies.VecTiles.transform.remove_feature_id
     sort: TileStache.Goodies.VecTiles.sort.transit
 post_process:

--- a/queries/transit.jinja2
+++ b/queries/transit.jinja2
@@ -51,7 +51,7 @@ SELECT
     %#tags AS tags
 
 FROM (
-  SELECT osm_id, way, name,ref, operator, route, railway, layer, tags
+  SELECT osm_id, way, name, ref, operator, route, railway, layer, tags
   FROM planet_osm_line
   WHERE
     {{ bounds|bbox_filter('way') }}
@@ -59,7 +59,7 @@ FROM (
 
   UNION ALL
 
-  SELECT osm_id, way, name,ref, operator, route, railway, layer, tags
+  SELECT osm_id, way, name, ref, operator, route, railway, layer, tags
   FROM planet_osm_polygon
   WHERE
     {{ bounds|bbox_filter('way') }}

--- a/queries/transit.jinja2
+++ b/queries/transit.jinja2
@@ -16,6 +16,7 @@ SELECT
     tags->'descent' AS descent,
     tags->'roundtrip' AS roundtrip,
     tags->'route_name' AS route_name,
+    layer,
     %#tags AS tags
 
 FROM planet_osm_line
@@ -23,3 +24,47 @@ FROM planet_osm_line
 WHERE
     {{ bounds|bbox_filter('way') }}
     AND mz_transit_level <= {{ zoom }}
+
+{% if zoom > 15 %}
+
+UNION ALL
+
+SELECT
+    osm_id AS __id__,
+    {% filter geometry %}way{% endfilter %} AS __geometry__,
+    name,
+    ref,
+    operator,
+    'platform' AS kind,
+    tags->'type' AS type,
+    tags->'colour' AS colour,
+    tags->'network' AS network,
+    tags->'state' AS state,
+    tags->'symbol' AS symbol,
+    tags->'description' AS description,
+    tags->'distance' AS distance,
+    tags->'ascent' AS ascent,
+    tags->'descent' AS descent,
+    tags->'roundtrip' AS roundtrip,
+    tags->'route_name' AS route_name,
+    layer,
+    %#tags AS tags
+
+FROM (
+  SELECT osm_id, way, name,ref, operator, route, railway, layer, tags
+  FROM planet_osm_line
+  WHERE
+    {{ bounds|bbox_filter('way') }}
+    AND railway='platform'
+
+  UNION ALL
+
+  SELECT osm_id, way, name,ref, operator, route, railway, layer, tags
+  FROM planet_osm_polygon
+  WHERE
+    {{ bounds|bbox_filter('way') }}
+    AND railway='platform'
+
+) platforms
+
+{% endif %}


### PR DESCRIPTION
Note that platforms can be either lines or polygons, and both are about equally common (2,279 lines, 1,612 polygons in North America) so will need handling in the style.

Needs a migration to add indexes. I figure the indexes are worthwhile because platforms are pretty rare, so scanning a whole block of line & polygon features would mean a lot more work per-query.

```SQL
CREATE INDEX planet_osm_line_railway_platform_index ON planet_osm_line USING gist(way) WHERE railway='platform';
CREATE INDEX planet_osm_polygon_railway_platform_index ON planet_osm_polygon USING gist(way) WHERE railway='platform';
```

Connects to #244.

@rmarianski could you review, please?