### PR TITLE
Move highway exits to POIs layer

### DIFF
--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -18,8 +18,6 @@ CREATE INDEX planet_osm_point_min_zoom_way_9_index ON planet_osm_point USING gis
 CREATE INDEX planet_osm_point_min_zoom_way_12_index ON planet_osm_point USING gist(way) WHERE mz_poi_min_zoom <= 12;
 CREATE INDEX planet_osm_point_min_zoom_way_15_index ON planet_osm_point USING gist(way) WHERE mz_poi_min_zoom <= 15;
 
-CREATE INDEX planet_osm_point_motorway_junction_index ON planet_osm_point USING gist(way) WHERE highway='motorway_junction';
-
 END $$;
 
 ANALYZE planet_osm_point;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -173,6 +173,7 @@ BEGIN
       WHEN amenity_val  = 'ski_rental'       THEN LEAST(zoom + 1.27, 17)
       WHEN amenity_val  = 'ski_school'       THEN LEAST(zoom + 2.30, 15)
       WHEN man_made_val = 'snow_cannon'      THEN LEAST(zoom + 4.90, 18)
+      WHEN highway_val  = 'motorway_junction' THEN 12
       WHEN (barrier_val IN ('gate')
             OR craft_val IN ('sawmill')
             OR highway_val IN ('gate', 'mini_roundabout')

--- a/queries.yaml
+++ b/queries.yaml
@@ -67,7 +67,7 @@ layers:
   roads:
     template: roads.jinja2
     start_zoom: 5
-    geometry_types: [Point, MultiPoint, LineString, MultiLineString]
+    geometry_types: [LineString, MultiLineString]
     simplify_start: 8
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -7,6 +7,8 @@ SELECT
     religion,
     sport,
     transit_routes,
+    ref,
+    tags->'exit_to' AS exit_to,
     %#tags AS tags,
     COALESCE("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic",
              "leisure", "lock", "man_made", "natural", "office", "power", "railway",
@@ -17,7 +19,7 @@ FROM (
   SELECT
     name, way, 0::real AS way_area, mz_poi_min_zoom AS min_zoom,
     osm_id,
-    cuisine, religion, sport,
+    cuisine, religion, sport, ref,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
     -- note: the mz_calculate_transit_routes function is pretty expensive,
     -- so we only want to calculate it when we actually need the result.
@@ -40,7 +42,7 @@ UNION ALL
   SELECT
     name, way, way_area, mz_poi_min_zoom AS min_zoom,
     osm_id,
-    cuisine, religion, sport,
+    cuisine, religion, sport, ref,
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
     NULL AS transit_routes,
     tags

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -136,57 +136,6 @@ WHERE
         'hike', 'sled', 'yes', 'snow_park', 'playground', 'ski_jump')
     AND (osm_id > 0 OR route = 'piste')
 
-UNION ALL
-
-SELECT
-    osm_id AS __id__,
-    {% filter geometry %}way{% endfilter %} AS __geometry__,
-    'openstreetmap' AS source,
-    name,
-    NULL AS aeroway,
-    NULL AS aerialway,
-    NULL AS bridge,
-    highway,
-    NULL AS ferry,
-    layer,
-    NULL AS railway,
-    NULL AS tunnel,
-    NULL AS oneway,
-    ref,
-    operator,
-    route,
-    tags->'type' AS type,
-    tags->'colour' AS colour,
-    NULL AS network,
-    tags->'state' AS state,
-    tags->'symbol' AS symbol,
-    tags->'description' AS description,
-    NULL AS distance,
-    NULL AS ascent,
-    NULL AS descent,
-    NULL AS roundtrip,
-    NULL AS route_name,
-    NULL AS motor_vehicle,
-    NULL AS service,
-    NULL AS piste_type,
-    NULL AS piste_difficulty,
-    NULL AS piste_grooming,
-    NULL AS piste_name,
-    NULL AS piste_abandoned,
-    NULL AS ski,
-    NULL AS snowshoe,
-    NULL AS symbol,
-    tags->'exit_to' AS exit_to,
-    NULL AS leisure,
-    NULL AS sport,
-    %#tags AS tags
-
-FROM planet_osm_point
-
-WHERE
-    {{ bounds|bbox_filter('way') }}
-    AND highway = 'motorway_junction'
-
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
Move highway exit points to the POIs layer, as they were the only points in the roads layer and it's lower risk of breaking someone else's map to have them in POIs.

Migration, which rolls back part of the migration for #426, is [here](https://gist.github.com/zerebubuth/f8eacf4ed65ea00589fa).

Connects to #160.

@rmarianski could you review, please?