### PR TITLE
Show subway stations starting at zoom 12

### DIFF
--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -9,8 +9,8 @@ ALTER TABLE planet_osm_point ADD COLUMN mz_poi_min_zoom REAL;
 -- the coalesce here is just an optimisation, as the poi level
 -- will always be NULL if all of the arguments are NULL.
 UPDATE planet_osm_point SET
-    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", 0::real)
-    WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway") IS NOT NULL;
+    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", 0::real)
+    WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway") IS NOT NULL;
 
 CREATE INDEX planet_osm_point_place_index ON planet_osm_point(place) WHERE name IS NOT NULL AND place IN ('borough', 'city', 'continent', 'country', 'county', 'district', 'farm', 'hamlet', 'island', 'isolated_dwelling', 'lake', 'locality', 'neighbourhood', 'ocean', 'province', 'quarter', 'sea', 'state', 'suburb', 'town', 'village');
 

--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -26,8 +26,8 @@ UPDATE planet_osm_polygon SET
 -- the coalesce here is just an optimisation, as the poi level
 -- will always be NULL if all of the arguments are NULL.
 UPDATE planet_osm_polygon SET
-    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", way_area)
-    WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway") IS NOT NULL;
+    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", way_area)
+    WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway") IS NOT NULL;
 
 CREATE INDEX planet_osm_polygon_is_landuse_col_index ON planet_osm_polygon(mz_is_landuse) WHERE mz_is_landuse=TRUE;
 

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -131,7 +131,7 @@ BEGIN
       WHEN natural_val IN ('peak', 'volcano')
         THEN 11 -- these are generally point features
       WHEN railway_val IN ('station')
-        THEN LEAST(zoom + 0.38, 13)
+        THEN LEAST(zoom + 0.38, 12)
       WHEN tourism_val = 'zoo'
         THEN LEAST(zoom + 3.00, 15)
       WHEN (natural_val IN ('spring')

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION mz_trigger_function_polygon()
 RETURNS TRIGGER AS $$
 DECLARE
     mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary");
-    mz_poi_min_zoom REAL = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW.way_area);
+    mz_poi_min_zoom REAL = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."tags"->'rental', NEW."shop", NEW."tourism", NEW."waterway", NEW.way_area);
 BEGIN
     IF mz_is_landuse THEN
         NEW.mz_is_landuse := TRUE;
@@ -23,7 +23,7 @@ CREATE TRIGGER mz_trigger_polygon BEFORE INSERT OR UPDATE ON planet_osm_polygon 
 CREATE OR REPLACE FUNCTION mz_trigger_function_point()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.mz_poi_min_zoom := mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", 0::real);
+    NEW.mz_poi_min_zoom := mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."tags"->'rental', NEW."shop", NEW."tourism", NEW."waterway", 0::real);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
Start showing all subway stations at zoom 12 in the tile data. The style then uses a cut-off based on the `kind_tile_rank` to choose which are visible.

Note that this PR includes a bunch of commits related to adding `rental` to the parameters of `mz_calculate_poi_level`, which should have been done as part of #432, but looks like it was missed out from that. This also [needs a migration](https://gist.github.com/zerebubuth/6b9e0fd7b7cdba5de117).

Connects to #369.

@rmarianski could you review, please?
