### PR TITLE
Add first attempt to automate running migrations.

### DIFF
--- a/data/migrations/run_migrations.sh
+++ b/data/migrations/run_migrations.sh
@@ -24,5 +24,5 @@ wait
 
 # re-enable triggers
 for table in planet_osm_point planet_osm_line planet_osm_polygon; do
-    psql -c "ALTER TABLE ${table} DISABLE TRIGGER USER" $*
+    psql -c "ALTER TABLE ${table} ENABLE TRIGGER USER" $*
 done

--- a/data/migrations/run_migrations.sh
+++ b/data/migrations/run_migrations.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+migration_dir=${0%/*}
+
+# first run functions and triggers, bailing if either of these fail, as they
+# are required by later steps.
+psql --set ON_ERROR_STOP=1 -f "${migration_dir}/../functions.sql" $*
+if [ $? -ne 0 ]; then echo "Installing new functions failed.">&2; exit 1; fi
+psql --set ON_ERROR_STOP=1 -f "${migration_dir}/../triggers.sql" $*
+if [ $? -ne 0 ]; then echo "Installing new triggers failed.">&2; exit 1; fi
+
+# then disable triggers
+for table in planet_osm_point planet_osm_line planet_osm_polygon; do
+    psql -c "ALTER TABLE ${table} DISABLE TRIGGER USER" $*
+done
+
+# run updates in parallel. note that we don't bail here, as we want to
+# re-enable the triggers regardless of whether we failed or not.
+for sql in ${migration_dir}/*.sql; do
+    psql -f "$sql" $* &
+done
+
+wait
+
+# re-enable triggers
+for table in planet_osm_point planet_osm_line planet_osm_polygon; do
+    psql -c "ALTER TABLE ${table} DISABLE TRIGGER USER" $*
+done

--- a/data/migrations/v0.6.0-planet_osm_line.sql
+++ b/data/migrations/v0.6.0-planet_osm_line.sql
@@ -1,0 +1,39 @@
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM   pg_class c
+  JOIN   pg_namespace n ON n.oid = c.relnamespace
+  WHERE  c.relname = 'planet_osm_line_piste_geom_index'
+  AND    n.nspname = 'public'
+  ) THEN
+
+  CREATE INDEX planet_osm_line_piste_geom_index ON planet_osm_line USING gist(way) WHERE tags ? 'piste:type';
+END IF;
+
+END$$;
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM   pg_class c
+  JOIN   pg_namespace n ON n.oid = c.relnamespace
+  WHERE  c.relname = 'planet_osm_line_railway_platform_index'
+  AND    n.nspname = 'public'
+  ) THEN
+
+  CREATE INDEX planet_osm_line_railway_platform_index ON planet_osm_line USING gist(way) WHERE railway='platform';
+END IF;
+
+END$$;
+
+UPDATE planet_osm_line
+  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, service, aerialway, leisure, sport, man_made, way)
+WHERE man_made IN ('snow_fence', 'pier')
+   OR (leisure = 'track'
+     AND sport IN ('athletics', 'running', 'horse_racing', 'bmx', 'disc_golf',
+       'cycling', 'ski_jumping', 'motor', 'karting', 'obstacle_course',
+       'equestrian', 'alpine_slide', 'soap_box_derby', 'mud_truck_racing',
+       'skiing', 'drag_racing', 'archery'));

--- a/data/migrations/v0.6.0-planet_osm_point.sql
+++ b/data/migrations/v0.6.0-planet_osm_point.sql
@@ -1,0 +1,10 @@
+UPDATE planet_osm_point
+  SET mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", 0::real)
+WHERE railway = 'station'
+   OR shop IN ('toys', 'ski', 'alcohol', 'wine', 'ice_cream')
+   OR "natural" = 'beach'
+   OR tags->'rental' = 'ski'
+   OR amenity IN ('ski_rental', 'ski_school', 'ice_cream')
+   OR man_made = 'snow_cannon'
+   OR highway = 'motorway_junction'
+   OR tourism = 'zoo';

--- a/data/migrations/v0.6.0-planet_osm_polygon.sql
+++ b/data/migrations/v0.6.0-planet_osm_polygon.sql
@@ -1,0 +1,32 @@
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM   pg_class c
+  JOIN   pg_namespace n ON n.oid = c.relnamespace
+  WHERE  c.relname = 'planet_osm_polygon_railway_platform_index'
+  AND    n.nspname = 'public'
+  ) THEN
+
+  CREATE INDEX planet_osm_polygon_railway_platform_index ON planet_osm_polygon USING gist(way) WHERE railway='platform';
+END IF;
+
+END$$;
+
+UPDATE planet_osm_polygon
+  SET mz_is_landuse = TRUE,
+      mz_landuse_min_zoom = mz_calculate_landuse_min_zoom("landuse", "leisure", "natural", "highway", "amenity", "aeroway", "tourism", "man_made", "power", "boundary", way_area)
+WHERE landuse IN ('rural', 'military', 'winter_sports')
+   OR "natural" = 'beach';
+
+UPDATE planet_osm_polygon
+  SET mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", way_area)
+WHERE railway = 'station'
+   OR shop IN ('toys', 'ski')
+   OR "natural" = 'beach'
+   OR tags->'rental' = 'ski'
+   OR amenity IN ('ski_rental', 'ski_school')
+   OR man_made = 'snow_cannon'
+   OR highway = 'motorway_junction'
+   OR tourism = 'zoo';

--- a/data/migrations/v0.6.0-planet_osm_polygon.sql
+++ b/data/migrations/v0.6.0-planet_osm_polygon.sql
@@ -23,10 +23,10 @@ WHERE landuse IN ('rural', 'military', 'winter_sports')
 UPDATE planet_osm_polygon
   SET mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", way_area)
 WHERE railway = 'station'
-   OR shop IN ('toys', 'ski')
+   OR shop IN ('toys', 'ski', 'alcohol', 'wine', 'ice_cream')
    OR "natural" = 'beach'
    OR tags->'rental' = 'ski'
-   OR amenity IN ('ski_rental', 'ski_school')
+   OR amenity IN ('ski_rental', 'ski_school', 'ice_cream')
    OR man_made = 'snow_cannon'
    OR highway = 'motorway_junction'
    OR tourism = 'zoo';

--- a/data/migrations/v0.6.0.sql
+++ b/data/migrations/v0.6.0.sql
@@ -1,0 +1,6 @@
+--
+-- drop old versions of functions
+--
+
+DROP FUNCTION IF EXISTS mz_calculate_road_level(text, text, text, text, text, text, way geometry);
+DROP FUNCTION IF EXISTS mz_calculate_poi_level(text, text, text, text, text, text, text, text, text, text, text, text, text, text, text, text, text, real);

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -18,7 +18,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
+-- do a drop-if-exists + create in a transaction to ensure that the script
+-- is idempotent.
+BEGIN;
+DROP TRIGGER IF EXISTS mz_trigger_polygon ON planet_osm_polygon;
 CREATE TRIGGER mz_trigger_polygon BEFORE INSERT OR UPDATE ON planet_osm_polygon FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_polygon();
+COMMIT;
 
 CREATE OR REPLACE FUNCTION mz_trigger_function_point()
 RETURNS TRIGGER AS $$
@@ -28,7 +33,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
+-- do a drop-if-exists + create in a transaction to ensure that the script
+-- is idempotent.
+BEGIN;
+DROP TRIGGER IF EXISTS mz_trigger_point ON planet_osm_point;
 CREATE TRIGGER mz_trigger_point BEFORE INSERT OR UPDATE ON planet_osm_point FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_point();
+COMMIT;
 
 CREATE OR REPLACE FUNCTION mz_trigger_function_line()
 RETURNS TRIGGER AS $$
@@ -39,4 +49,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
+-- do a drop-if-exists + create in a transaction to ensure that the script
+-- is idempotent.
+BEGIN;
+DROP TRIGGER IF EXISTS mz_trigger_line ON planet_osm_line;
 CREATE TRIGGER mz_trigger_line BEFORE INSERT OR UPDATE ON planet_osm_line FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_line();
+COMMIT;


### PR DESCRIPTION
There's a shell script, `data/migrations/run_migrations.sh`, which will run the `functions.sql` and `triggers.sql` and, if both exited cleanly, run every `data/migrations/*.sql` in parallel. By convention, we might want to keep one file per table, plus additional ones for anything "global" like dropping old function signatures.

The whole thing is supposed to be idempotent, and I can run it against my local database repeatedly okay.

@rmarianski could you review, please?