### PR TITLE
Skip "cleanup" files.

### DIFF
--- a/data/migrations/run_migrations.sh
+++ b/data/migrations/run_migrations.sh
@@ -17,7 +17,11 @@ done
 # run updates in parallel. note that we don't bail here, as we want to
 # re-enable the triggers regardless of whether we failed or not.
 for sql in ${migration_dir}/*.sql; do
-    psql -f "$sql" $* &
+    if [[ $sql = *migrate*.sql ]]; then
+        echo "SKIPPING $sql - run this after the code migration."
+    else
+        psql -f "$sql" $* &
+    fi
 done
 
 wait

--- a/data/migrations/run_migrations.sh
+++ b/data/migrations/run_migrations.sh
@@ -17,7 +17,7 @@ done
 # run updates in parallel. note that we don't bail here, as we want to
 # re-enable the triggers regardless of whether we failed or not.
 for sql in ${migration_dir}/*.sql; do
-    if [[ $sql = *migrate*.sql ]]; then
+    if [[ $sql = *cleanup*.sql ]]; then
         echo "SKIPPING $sql - run this after the code migration."
     else
         psql -f "$sql" $* &


### PR DESCRIPTION
As @rmarianski spotted, we sometimes need to delay part of the migration (e.g: dropping functions used in queries) until after the code has been deployed. This allows that by skipping any file in the migrations directory with "cleanup" as part of the name.

@rmarianski could you review, please?