### PR TITLE
Select fitness-related POIs.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -178,6 +178,10 @@ BEGIN
       WHEN amenity_val  = 'ski_rental'       THEN LEAST(zoom + 1.27, 17)
       WHEN amenity_val  = 'ski_school'       THEN LEAST(zoom + 2.30, 15)
       WHEN man_made_val = 'snow_cannon'      THEN LEAST(zoom + 4.90, 18)
+      WHEN leisure_val  = 'sports_centre'    THEN LEAST(zoom + 3.98, 17)
+      WHEN leisure_val  = 'fitness_centre'   THEN LEAST(zoom + 3.98, 17)
+      WHEN leisure_val  = 'fitness_station'  THEN LEAST(zoom + 3.98, 17)
+      WHEN amenity_val  = 'gym'              THEN LEAST(zoom + 3.98, 17)
       WHEN highway_val  = 'motorway_junction' THEN 12
       WHEN (barrier_val IN ('gate')
             OR craft_val IN ('sawmill')

--- a/data/migrations/v0.7.0-planet_osm_point.sql
+++ b/data/migrations/v0.7.0-planet_osm_point.sql
@@ -1,0 +1,5 @@
+UPDATE planet_osm_point SET
+  mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", 0::real)
+  WHERE
+    "leisure" IN ('sports_centre', 'fitness_centre', 'fitness_station') OR
+    "amenity" = 'gym';

--- a/data/migrations/v0.7.0-planet_osm_polygon.sql
+++ b/data/migrations/v0.7.0-planet_osm_polygon.sql
@@ -1,0 +1,5 @@
+UPDATE planet_osm_polygon SET
+  mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "tags"->'rental', "shop", "tourism", "waterway", way_area)
+  WHERE
+    "leisure" IN ('sports_centre', 'fitness_centre', 'fitness_station') OR
+    "amenity" = 'gym';

--- a/queries.yaml
+++ b/queries.yaml
@@ -112,6 +112,7 @@ layers:
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.add_iata_code_to_airports
+      - TileStache.Goodies.VecTiles.transform.normalize_leisure_kind
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
       - TileStache.Goodies.VecTiles.transform.tags_remove
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties


### PR DESCRIPTION
This selects fitness-related POIs and normalises them to `kind=fitness`.

Connects to #465. Requires mapzen/TileStache#110.

@nvkelso could you review, please?