### PR TITLE
Merge road segments

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -271,3 +271,8 @@ post_process:
     params:
       source_layer: roads
       start_zoom: 9
+  - fn: TileStache.Goodies.VecTiles.transform.merge_features
+    params:
+      source_layer: roads
+      start_zoom: 8
+      end_zoom: 16

--- a/queries.yaml
+++ b/queries.yaml
@@ -273,6 +273,26 @@ post_process:
     params:
       source_layer: roads
       start_zoom: 9
+  - fn: TileStache.Goodies.VecTiles.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 14
+      properties: [is_bridge, is_tunnel, oneway]
+      where: >-
+        (kind == 'path' and zoom < 15) or
+        (kind in ['minor_road', 'major_road', 'highway', 'rail'] and zoom < 13)
+  - fn: TileStache.Goodies.VecTiles.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 16
+      properties: [name, ref, network]
+      where: >-
+        (kind == 'path' and zoom < 17) or
+        (kind in ['minor_road', 'rail'] and zoom < 15) or
+        (kind == 'major_road' and zoom < 12) or
+        (kind == 'highway' and zoom < 7)
   - fn: TileStache.Goodies.VecTiles.transform.merge_features
     params:
       source_layer: roads

--- a/queries.yaml
+++ b/queries.yaml
@@ -278,10 +278,17 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 14
-      properties: [is_bridge, is_tunnel, oneway]
+      properties: [is_bridge, is_tunnel]
       where: >-
         (kind == 'path' and zoom < 15) or
         (kind in ['minor_road', 'major_road', 'highway', 'rail'] and zoom < 13)
+  # drop all oneway tags below zoom 14 (i.e: zoom >= 15) for all types.
+  - fn: TileStache.Goodies.VecTiles.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 14
+      properties: [oneway]
   - fn: TileStache.Goodies.VecTiles.transform.drop_properties
     params:
       source_layer: roads
@@ -289,10 +296,21 @@ post_process:
       end_zoom: 16
       properties: [name, ref, network]
       where: >-
-        (kind == 'path' and zoom < 17) or
-        (kind in ['minor_road', 'rail'] and zoom < 15) or
-        (kind == 'major_road' and zoom < 12) or
+        (kind == 'path' and zoom < 16) or
+        (kind == 'rail' and zoom < 15) or
+        (kind == 'minor_road' and zoom < 14) or
+        (kind == 'major_road' and zoom < 11) or
         (kind == 'highway' and zoom < 7)
+  # this is a patch to get rid of name, but keep ref & network, for highways
+  # when zoom < 11.
+  - fn: TileStache.Goodies.VecTiles.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 10
+      end_zoom: 7
+      properties: [name]
+      where: >-
+        kind == 'highway'
   - fn: TileStache.Goodies.VecTiles.transform.merge_features
     params:
       source_layer: roads

--- a/queries.yaml
+++ b/queries.yaml
@@ -306,8 +306,8 @@ post_process:
   - fn: TileStache.Goodies.VecTiles.transform.drop_properties
     params:
       source_layer: roads
-      start_zoom: 10
-      end_zoom: 7
+      start_zoom: 7
+      end_zoom: 10
       properties: [name]
       where: >-
         kind == 'highway'


### PR DESCRIPTION
This configures the dropping of some properties and the merging of some road segments.

The configuration here is to drop bridge, tunnel and oneway properties for paths below z15 and other kinds of road and rail below 13. This is based on the [style](https://github.com/nvkelso/tangram-skin-and-bones/blob/gh-pages/scene.yaml#L2649-L2657) which seems to mostly not show bridges or tunnels below those zoom levels (and doesn't show oneway at all?), but this should be checked.

It is also configured to drop name, ref and network properties below certain zooms configured per-kind. Again, this was based on a reading of the style, and should be checked.

The improvements in feature count and tile size were based on this configuration, and could be improved further by dropping more properties later, or some improvement could be sacrificed in return for keeping those properties into lower zooms.

Connects to #358. Requires mapzen/TileStache#111.

@nvkelso could you review, please?
