### PR TITLE
Don't import historic WOF neighbourhoods

### DIFF
--- a/data/migrations/v0.7.0-wof_neighbourhoods.sql
+++ b/data/migrations/v0.7.0-wof_neighbourhoods.sql
@@ -1,0 +1,29 @@
+-- need to add the inception and cessation columns to handle
+-- neighbourhood lifetime. we default these to:
+--   '0001-01-01' for inception and
+--   '9999-12-31' for cessation
+-- because these are the earliest/latest dates for an EDTF
+-- 'uuuu' format time, which is what we default to when the
+-- WOF neighbourhood doesn't specify what time it actually
+-- wants.
+--
+-- futher, we add a "visible now" column which is updated
+-- by running the
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM   pg_attribute
+  WHERE  attrelid = 'wof_neighbourhood'::regclass
+  AND    attname = 'inception'
+  AND    NOT attisdropped
+  ) THEN
+
+  ALTER TABLE wof_neighbourhood
+    ADD COLUMN inception DATE NOT NULL DEFAULT '0001-01-01',
+    ADD COLUMN cessation DATE NOT NULL DEFAULT '9999-12-31',
+    ADD COLUMN is_visible BOOLEAN NOT NULL DEFAULT true;
+END IF;
+
+END$$;

--- a/data/wof-schema.sql
+++ b/data/wof-schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE wof_neighbourhood (
   min_zoom SMALLINT NOT NULL,
   max_zoom SMALLINT NOT NULL,
   is_landuse_aoi BOOLEAN,
+  inception DATE NOT NULL DEFAULT '0001-01-01',
+  cessation DATE NOT NULL DEFAULT '9999-12-31',
   label_position geometry(Point, 900913) NOT NULL,
   geometry geometry(Geometry, 900913) NOT NULL
 );

--- a/queries/places.jinja2
+++ b/queries/places.jinja2
@@ -92,6 +92,7 @@ FROM wof_neighbourhood wof_n
 INNER JOIN wof_neighbourhood_placetype wof_np ON wof_n.placetype = wof_np.placetype_code
 
 WHERE
+  wof_n.is_visible AND
   {{ bounds|bbox_filter('label_position') }} AND
   {{ zoom + 1 }} >= min_zoom AND
   {{ zoom - 1 }} <= max_zoom


### PR DESCRIPTION
Migration to add `inception`, `cessation`, `is_visible` columns to WOF neighbourhoods. Update to queries to use the visibility information.

Requires and is required by mapzen/tilequeue#63. Connects to mapzen/tilequeue#59.

@nvkelso could you review, please?