### PR TITLE
Clip buildings to 3x tile bounds, not 1x.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -89,6 +89,7 @@ layers:
   buildings:
     template: buildings.jinja2
     start_zoom: 13
+    clip_factor: 3.0
     geometry_types: [Point, MultiPoint, Polygon, MultiPolygon]
     transform:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict


### PR DESCRIPTION
Note that the tests didn't need updating, since I forgot to update them for 1x, they're still calibrated for 3x.

Connects to #490.

@nvkelso could you review, please?
