### PR TITLE
Move WOF table creation to start of updates script

### DIFF
--- a/data/perform-sql-updates.sh
+++ b/data/perform-sql-updates.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# apply wof schema first, as functions now depend on it.
+echo "Creating WOF schema..."
+psql $@ -f wof-schema.sql
+echo "done."
+
 # subsequent sql depends on functions installed
 echo "Creating functions..."
 psql $@ -f functions.sql
@@ -11,7 +16,6 @@ psql $@ -f apply-updates-non-planet-tables.sql &
 psql $@ -f apply-planet_osm_polygon.sql &
 psql $@ -f apply-planet_osm_line.sql &
 psql $@ -f apply-planet_osm_point.sql &
-psql $@ -f wof-schema.sql &
 wait
 echo "done."
 

--- a/data/wof-schema.sql
+++ b/data/wof-schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE wof_neighbourhood (
   is_landuse_aoi BOOLEAN,
   inception DATE NOT NULL DEFAULT '0001-01-01',
   cessation DATE NOT NULL DEFAULT '9999-12-31',
+  is_visible BOOLEAN NOT NULL DEFAULT true,
   label_position geometry(Point, 900913) NOT NULL,
   geometry geometry(Geometry, 900913) NOT NULL
 );


### PR DESCRIPTION
So that the WOF tables are present when the functions are defined. Also adds the `is_visible` column, which was missing from the previous PR.

@nvkelso could you review, please?
