### PR TITLE
Fix stations for flat nodes

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -659,15 +659,15 @@ BEGIN
   );
 
   stations_and_stops := ARRAY(
-    SELECT DISTINCT n.id
-    FROM planet_osm_nodes n
+    SELECT DISTINCT p.osm_id AS id
+    FROM planet_osm_point p
     JOIN (SELECT DISTINCT unnest(r.parts[1:r.way_off]) AS node_id
           FROM planet_osm_rels r
 	  WHERE r.id = ANY(stop_area_ids)) r
-    ON r.node_id = n.id
+    ON r.node_id = p.osm_id
     WHERE (
-      mz_rel_get_tag(n.tags, 'railway') IN ('station', 'stop') OR
-      mz_rel_get_tag(n.tags, 'public_transport') IN ('stop', 'stop_position'))
+      p.railway IN ('station', 'stop') OR
+      p.public_transport IN ('stop', 'stop_position'))
     -- manually re-include the original station node, in case it's
     -- not part of a public_transport=stop_area relation.
     UNION SELECT station_node_id AS id

--- a/data/migrations/v0.8.0-cleanup.sql
+++ b/data/migrations/v0.8.0-cleanup.sql
@@ -1,0 +1,3 @@
+-- old version of the transit routes function - the new version
+-- takes a node ID and/or a way ID.
+DROP FUNCTION IF EXISTS mz_calculate_transit_routes(BIGINT);

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -30,7 +30,7 @@ FROM (
     -- so we only want to calculate it when we actually need the result.
     CASE
       WHEN railway='station' AND osm_id > 0
-        THEN mz_calculate_transit_routes(osm_id)
+        THEN mz_calculate_transit_routes(osm_id, NULL)
       ELSE NULL::text[]
     END AS transit_routes,
     tags
@@ -51,7 +51,13 @@ UNION ALL
     aerialway, aeroway, amenity, barrier, craft, highway, historic, leisure, lock, man_made, "natural", office, power, railway, shop, tourism, waterway,
     tags->'attraction' AS attraction,
     tags->'zoo' AS zoo,
-    NULL AS transit_routes,
+    -- note: the mz_calculate_transit_routes function is pretty expensive,
+    -- so we only want to calculate it when we actually need the result.
+    CASE
+      WHEN railway='station' AND osm_id > 0
+        THEN mz_calculate_transit_routes(NULL, osm_id)
+      ELSE NULL::text[]
+    END AS transit_routes,
     tags
 
   FROM

--- a/test/507-routes-via-stop-positions.py
+++ b/test/507-routes-via-stop-positions.py
@@ -1,5 +1,5 @@
 stations = [
-    (17, 38596, 49262, 'Penn Station', 895371274L, [
+    (17, 38596, 49262, 'Penn Station', 895371274L, 1, [
         '2100-2297', # Acela Express
         '68-69', # Adirondack
         '50-51', # Cardinal
@@ -15,9 +15,9 @@ stations = [
         '91-92', # Silver Star
         '54-57', # Vermonter
     ]),
-    (17, 37639, 49960, 'Camden Station', 845910705L, ['Camden Line']),
-    (17, 20958, 50667, 'Castro MUNI',    297863017L, ['K', 'L', 'M', 'T']),
-    (17, 38163, 49642, '30th Street',     32272623L, [
+    (17, 37639, 49960, 'Camden Station', 845910705L, 2, ['Camden Line']),
+    (17, 20958, 50667, 'Castro MUNI',    297863017L, 1, ['K', 'L', 'M', 'T']),
+    (17, 38163, 49642, '30th Street',     32272623L, 1, [
         '2100-2297', # Acela Express
         '79-80', # Carolinian
         '19-20', # Crescent
@@ -33,7 +33,7 @@ stations = [
     ])
 ]
 
-for z, x, y, name, osm_id, expected_routes in stations:
+for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
     with features_in_tile_layer(z, x, y, 'pois') as pois:
         found = False
 
@@ -42,6 +42,12 @@ for z, x, y, name, osm_id, expected_routes in stations:
             if props['id'] == osm_id:
                 found = True
                 routes = props.get('transit_routes', list())
+                rank = props['kind_tile_rank']
+
+                if rank > expected_rank:
+                    raise Exception("Found %r, and was expecting a rank "
+                                    "of %r or less, but got %r."
+                                    % (name, expected_rank, rank))
 
                 for r in expected_routes:
                     count = 0

--- a/test/507-routes-via-stop-positions.py
+++ b/test/507-routes-via-stop-positions.py
@@ -16,7 +16,21 @@ stations = [
         '54-57', # Vermonter
     ]),
     (17, 37639, 49960, 'Camden Station', 845910705L, ['Camden Line']),
-    (17, 20958, 50667, 'Castro MUNI',    297863017L, ['K', 'L', 'M', 'T'])
+    (17, 20958, 50667, 'Castro MUNI',    297863017L, ['K', 'L', 'M', 'T']),
+    (17, 38163, 49642, '30th Street',     32272623L, [
+        '2100-2297', # Acela Express
+        '79-80', # Carolinian
+        '19-20', # Crescent
+        '600-674', # Keystone Service
+        '82-198', # Northeast Regional (Boston/Springfield & Lynchburg)
+        '89-90', # Palmetto
+        'Chestnut Hill West Line', # SEPTA - Chestnut Hill West Line
+        'Cynwyd Line', # SEPTA - Cynwyd Line
+        'Media/Elwyn Line', # SEPTA - Media/Elwyn Line
+        'Trenton Line', # SEPTA - Trenton Line
+        'Wilmington/Newark Line', # SEPTA - Wilmington/Newark Line
+        '91-92', # Silver Star
+    ])
 ]
 
 for z, x, y, name, osm_id, expected_routes in stations:

--- a/test/507-routes-via-stop-positions.py
+++ b/test/507-routes-via-stop-positions.py
@@ -1,0 +1,45 @@
+stations = [
+    (17, 38596, 49262, 'Penn Station', 895371274L, [
+        '2100-2297', # Acela Express
+        '68-69', # Adirondack
+        '50-51', # Cardinal
+        '79-80', # Carolinian
+        '19-20', # Crescent
+        '230-296', # Empire Service
+        '600-674', # Keystone Service
+        '63', # Maple Leaf (Northbound)
+        '64', # Maple Leaf (Southbound)
+        '89-90', # Palmetto
+        '42-43', # Pennsylvanian
+        '97-98', # Silver Meteor
+        '91-92', # Silver Star
+        '54-57', # Vermonter
+    ]),
+    (17, 37639, 49960, 'Camden Station', 845910705L, ['Camden Line']),
+    (17, 20958, 50667, 'Castro MUNI',    297863017L, ['K', 'L', 'M', 'T'])
+]
+
+for z, x, y, name, osm_id, expected_routes in stations:
+    with features_in_tile_layer(z, x, y, 'pois') as pois:
+        found = False
+
+        for poi in pois:
+            props = poi['properties']
+            if props['id'] == osm_id:
+                found = True
+                routes = props.get('transit_routes', list())
+
+                for r in expected_routes:
+                    count = 0
+                    for route in routes:
+                        if r in route:
+                            count = count + 1
+
+                    if count == 0:
+                        raise Exception("Found %r, and was expecting at "
+                                        "least one %r route, but found "
+                                        "none. Routes: %r"
+                                        % (name, r, routes))
+
+        if not found:
+            raise Exception("Did not find %r (ID=%r) in tile." % (name, osm_id))


### PR DESCRIPTION
Fixes a bug (sort of) which was stopping us finding all the relevant routes when running on a prod database with a flat nodes file rather than a `planet_osm_nodes` table. Also, adds a test for railway station routes. Also extends the function so that it works with ways (i.e: railway buildings) as well as just nodes/points.

Connects to #507.

@nvkelso, could you review please?
