### PR TITLE
Make larger 'big box' stores appear at lower zooms.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -191,6 +191,8 @@ BEGIN
       WHEN amenity_val  = 'ferry_terminal'   THEN LEAST(zoom + 3.20, 15)
       WHEN amenity_val  = 'school'           THEN LEAST(zoom + 2.30, 15)
       WHEN shop_val     = 'electronics'      THEN LEAST(zoom + 3.30, 17)
+      WHEN shop_val IN ('department_store', 'supermarket', 'doityourself',
+                        'hardware', 'trade') THEN LEAST(zoom + 3.29, 17)
       WHEN natural_val  = 'beach'            THEN LEAST(zoom + 3.20, 14)
       WHEN tags->'rental' = 'ski'            THEN LEAST(zoom + 1.27, 17)
       WHEN shop_val     = 'ski'              THEN LEAST(zoom + 1.27, 17)
@@ -253,7 +255,6 @@ BEGIN
                    OR historic_val IN ('archaeological_site')
                    OR man_made_val IN ('windmill')
                    OR natural_val IN ('tree')
-                   OR shop_val IN ('department_store', 'supermarket')
                    OR tourism_val IN ('camp_site', 'caravan_site', 'information', 'viewpoint')) THEN 16
              WHEN (amenity_val IN (
                  'atm', 'bicycle_rental', 'bicycle_parking', 'bus_stop',
@@ -272,7 +273,7 @@ BEGIN
                 'therapist', 'travel_agent', 'yes')
                    OR shop_val IN ('bakery', 'bicycle', 'books', 'butcher', 'car', 'car_repair',
                                  'clothes', 'computer', 'convenience',
-                                 'doityourself', 'dry_cleaning', 'fashion', 'florist', 'gift',
+                                 'dry_cleaning', 'fashion', 'florist', 'gift',
                                  'greengrocer', 'hairdresser', 'jewelry', 'mobile_phone',
                                  'optician', 'pet')
                    OR tourism_val IN ('bed_and_breakfast', 'chalet', 'guest_house', 'hostel')

--- a/data/migrations/v0.8.0-point.sql
+++ b/data/migrations/v0.8.0-point.sql
@@ -8,4 +8,6 @@ UPDATE planet_osm_point SET
     "amenity" IN ('social_facility', 'clinic', 'doctors', 'dentist',
       'kindergarten', 'childcare', 'toilets') OR
     "tags"->'healthcare' = 'midwife' OR
-    "tourism" IN ('hotel', 'motel');
+    "tourism" IN ('hotel', 'motel') OR
+    "shop" IN ('department_store', 'supermarket', 'doityourself',
+               'hardware', 'trade');

--- a/data/migrations/v0.8.0-polygon.sql
+++ b/data/migrations/v0.8.0-polygon.sql
@@ -17,4 +17,6 @@ UPDATE planet_osm_polygon SET
     "amenity" IN ('social_facility', 'clinic', 'doctors', 'dentist',
       'kindergarten', 'childcare', 'toilets') OR
     "tags"->'healthcare' = 'midwife' OR
-    "tourism" IN ('hotel', 'motel');
+    "tourism" IN ('hotel', 'motel') OR
+    "shop" IN ('department_store', 'supermarket', 'doityourself',
+               'hardware', 'trade');

--- a/test/520-big-box-stores.py
+++ b/test/520-big-box-stores.py
@@ -1,0 +1,13 @@
+tiles = [
+    # there are TWO Target stores in this tile - and both are huge!
+    ['14/2618/6338', set([152722810, 56149856]), 'department_store'],
+    ['14/2620/6333', 219072560, 'supermarket'],
+    ['14/2618/6338', 344057345, 'supermarket'],
+    ['14/2621/6334', 259001359, 'doityourself'],
+    ['15/5240/12668', 194906343, 'supermarket'],
+    ['15/5236/12666', -3585039, 'supermarket'],
+]
+
+for zxy, id, kind in tiles:
+    z, x, y = map(int, zxy.split('/'))
+    assert_has_feature(z, x, y, 'pois', {'kind': kind, 'id': id})


### PR DESCRIPTION
Most of these were pulled up from a flat zoom level. Added a test at the zoom mentioned in #520. Note that one of the Targets has two `id`s because we merge points with the same name within a 1-tile radius, and those are too close together. So one will get merged away.

Connects to #520.

@rmarianski could you review, please?