### PR TITLE
Fix tests for limited dataset, sort key changes

### DIFF
--- a/test/343-winter-sports-resorts.py
+++ b/test/343-winter-sports-resorts.py
@@ -1,4 +1,4 @@
 assert_has_feature(
     15, 5467, 12531, 'landuse',
     { 'kind': 'winter_sports',
-      'sort_key': 2 })
+      'sort_key': 27 })

--- a/test/400-bay-water.py
+++ b/test/400-bay-water.py
@@ -3,12 +3,13 @@ assert_has_feature(
     14, 2623, 6318, 'water',
     { 'kind': 'bay', 'label_placement': 'yes' })
 
-# osm_id: 360566115 name: Byron strait
+# osm_id: -1019862, name: Sansum Narrows
 assert_has_feature(
-    14, 15043, 8311, 'water',
+    11, 321, 705, 'water',
     { 'kind': 'strait', 'label_placement': 'yes' })
 
+# None in North America?
 # osm_id: -1451065 name: Horsens Fjord
-assert_has_feature(
-    14, 8645, 5114, 'water',
-    { 'kind': 'fjord', 'label_placement': 'yes' })
+#assert_has_feature(
+#    14, 8645, 5114, 'water',
+#    { 'kind': 'fjord', 'label_placement': 'yes' })


### PR DESCRIPTION
The sort key changes in mapzen/TileStache#116 broke the winter sports test.

The bay / strait / fjord data came from all over the world, but we test with the North America extract. I couldn't find a fjord, but found a suitable strait.

@rmarianski could you review, please?
