### PR TITLE
Fix missing sort key on water boundaries

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -488,6 +488,7 @@ Mapzen calculates the composite exterior edge for overlapping water polygons and
 * `kind`: detailed below, per geometry type
 * `source`: one of `naturalearthdata.com`, `openstreetmapdata.com`, `openstreetmap.org`
 * `boundary`: `yes`, on lines only. See description above.
+* `sort_key`: a suggestion for which order to draw features. The value is an integer where smaller numbers suggest that features should be "behind" features with larger numbers.
 
 **Water properties (common optional):**
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -209,15 +209,6 @@ post_process:
     params:
       source_layer: transit
       target_value_type: int
-  - fn: TileStache.Goodies.VecTiles.transform.csv_match_properties
-    resources:
-      matcher:
-        type: file
-        init_fn: TileStache.Goodies.VecTiles.transform.CSVMatcher
-        path: spreadsheets/water.csv
-    params:
-      source_layer: water
-      target_value_type: int
   - fn: TileStache.Goodies.VecTiles.transform.drop_properties
     params:
       source_layer: roads
@@ -249,6 +240,17 @@ post_process:
         boundary: "yes"
         area: true
       snap_tolerance: 0.125
+  # have to do the water properties matching _after_ exterior boundaries
+  # as it depends on having the "boundary: yes" property available.
+  - fn: TileStache.Goodies.VecTiles.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: TileStache.Goodies.VecTiles.transform.CSVMatcher
+        path: spreadsheets/water.csv
+    params:
+      source_layer: water
+      target_value_type: int
   - fn: TileStache.Goodies.VecTiles.transform.overlap
     params:
       base_layer: buildings

--- a/test/552-water-boundary-sort-key.py
+++ b/test/552-water-boundary-sort-key.py
@@ -1,0 +1,4 @@
+# from https://github.com/mapzen/vector-datasource/issues/552
+assert_has_feature(
+    19, 83900, 202617, "water",
+    {"kind": "ocean", "boundary": "yes", "sort_key": 205})


### PR DESCRIPTION
Adds a new test, and updates the docs.

The issue was that the `boundary: yes` property is added by the `exterior_boundaries` post-process, but that was being run after the sort key was added.

Connects to #552.

@nvkelso could you review, please?