### PR TITLE
Remove disused railway stations

### DIFF
--- a/data/apply-planet_osm_point.sql
+++ b/data/apply-planet_osm_point.sql
@@ -9,7 +9,7 @@ ALTER TABLE planet_osm_point ADD COLUMN mz_poi_min_zoom REAL;
 -- the coalesce here is just an optimisation, as the poi level
 -- will always be NULL if all of the arguments are NULL.
 UPDATE planet_osm_point SET
-    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags", 0::real)
+    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "disused", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags", 0::real)
     WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags"->'rental', "tags"->'zoo', "tags"->'attraction', tags->'healthcare') IS NOT NULL;
 
 CREATE INDEX planet_osm_point_place_index ON planet_osm_point(place) WHERE name IS NOT NULL AND place IN ('borough', 'city', 'continent', 'country', 'county', 'district', 'farm', 'hamlet', 'island', 'isolated_dwelling', 'lake', 'locality', 'neighbourhood', 'ocean', 'province', 'quarter', 'sea', 'state', 'suburb', 'town', 'village');

--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -25,7 +25,7 @@ UPDATE planet_osm_polygon SET
 -- the coalesce here is just an optimisation, as the poi level
 -- will always be NULL if all of the arguments are NULL.
 UPDATE planet_osm_polygon SET
-    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags", way_area)
+    mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity", "barrier", "craft", "disused", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags", way_area)
     WHERE coalesce("aerialway", "aeroway", "amenity", "barrier", "craft", "emergency", "highway", "historic", "leisure", "lock", "man_made", "natural", "office", "power", "railway", "shop", "tourism", "waterway", "tags"->'rental', "tags"->'zoo', "tags"->'attraction', tags->'healthcare') IS NOT NULL;
 
 CREATE INDEX planet_osm_polygon_is_landuse_col_index ON planet_osm_polygon(mz_is_landuse) WHERE mz_is_landuse=TRUE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -117,6 +117,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_poi_level(
     amenity_val text,
     barrier_val text,
     craft_val text,
+    disused_val text,
     emergency_val text,
     highway_val text,
     historic_val text,
@@ -140,6 +141,9 @@ BEGIN
   zoom = mz_one_pixel_zoom(way_area);
   RETURN
     CASE
+      -- drop anything which is tagged as disused
+      WHEN disused_val <> 'no'
+        THEN NULL
       WHEN aeroway_val IN ('aerodrome', 'airport')
         THEN LEAST(zoom + 4.12, 13)
       WHEN amenity_val = 'hospital'

--- a/data/migrations/v0.9.0-cleanup.sql
+++ b/data/migrations/v0.9.0-cleanup.sql
@@ -1,0 +1,4 @@
+-- old version of the POI level calculation without the 'disused' parameter.
+DROP FUNCTION IF EXISTS mz_calculate_poi_level(
+  text, text, text, text, text, text, text, text, text, text, text, text, text,
+  text, text, text, text, text, hstore, real);

--- a/data/migrations/v0.9.0-points.sql
+++ b/data/migrations/v0.9.0-points.sql
@@ -1,0 +1,7 @@
+UPDATE planet_osm_point SET
+  mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity",
+    "barrier", "craft", "disused", "emergency", "highway", "historic",
+    "leisure", "lock", "man_made", "natural", "office", "power", "railway",
+    "shop", "tourism", "waterway", "tags", 0::real)
+  WHERE
+    "disused" <> 'no';

--- a/data/migrations/v0.9.0-polygons.sql
+++ b/data/migrations/v0.9.0-polygons.sql
@@ -1,0 +1,7 @@
+UPDATE planet_osm_polygon SET
+  mz_poi_min_zoom = mz_calculate_poi_level("aerialway", "aeroway", "amenity",
+    "barrier", "craft", "disused", "emergency", "highway", "historic",
+    "leisure", "lock", "man_made", "natural", "office", "power", "railway",
+    "shop", "tourism", "waterway", "tags", way_area)
+  WHERE
+    "disused" <> 'no';

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION mz_trigger_function_polygon()
 RETURNS TRIGGER AS $$
 DECLARE
     mz_is_landuse BOOLEAN = mz_calculate_is_landuse(NEW."landuse", NEW."leisure", NEW."natural", NEW."highway", NEW."amenity", NEW."aeroway", NEW."tourism", NEW."man_made", NEW."power", NEW."boundary", NEW."tags");
-    mz_poi_min_zoom REAL = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."emergency", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW."tags", NEW.way_area);
+    mz_poi_min_zoom REAL = mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."disused", NEW."emergency", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW."tags", NEW.way_area);
 BEGIN
     IF mz_is_landuse THEN
         NEW.mz_is_landuse := TRUE;
@@ -28,7 +28,7 @@ COMMIT;
 CREATE OR REPLACE FUNCTION mz_trigger_function_point()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.mz_poi_min_zoom := mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."emergency", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW."tags", 0::real);
+    NEW.mz_poi_min_zoom := mz_calculate_poi_level(NEW."aerialway", NEW."aeroway", NEW."amenity", NEW."barrier", NEW."craft", NEW."disused", NEW."emergency", NEW."highway", NEW."historic", NEW."leisure", NEW."lock", NEW."man_made", NEW."natural", NEW."office", NEW."power", NEW."railway", NEW."shop", NEW."tourism", NEW."waterway", NEW."tags", 0::real);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -297,6 +297,8 @@ The `pois` layer should be used in conjuction with `landuse` (parks, etc) label_
 
 Points of interest from OpenStreetMap, with per-zoom selections similar to the primary [OSM.org Mapnik stylesheet](https://trac.openstreetmap.org/browser/subversion/applications/rendering/mapnik).
 
+Features from OpenStreetMap which are tagged `disused=*` for any other value than `disused=no` are not included in the data.
+
 **POI properties (common):**
 
 * `name`

--- a/test/368-disused-railway-stations.py
+++ b/test/368-disused-railway-stations.py
@@ -1,0 +1,12 @@
+# Old South Ferry (1) (disused=yes)
+assert_no_matching_feature(
+    19, 154354, 197144, 'pois',
+    {'kind': 'station', 'id': 2086974744})
+
+# Valle, AZ (disused=station)
+assert_no_matching_feature(
+    19, 98740, 206504, 'pois',
+    {'id': 366220389})
+
+# Sadly, we seem to be lacking a disused=no object in
+# North America to use for testing.


### PR DESCRIPTION
Removes all POIs tagged with `disused=*` other than `disused=no`.

Connects to #368.

@rmarianski could you review, please?