### PR TITLE
Filter on parenthetical properties

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -173,7 +173,7 @@ Mapzen calculates the `landuse_kind` value by intercutting `buildings` with the 
 
 **Building kind values:**
 
-* Buildings polygons and label_position points have `kind` values that are a straight passthru of the raw OpenStreetMap `building=*` and `building:part` values.
+* Buildings polygons and label_position points either have `kind` values that are a straight passthru of the raw OpenStreetMap `building=*` and `building:part` values. Label position points may also be one of `closed` or `historical` if the original building name ended in "(closed)" or "(historical)", respectively. These points will have a `min_zoom` of 17, suggesting that they are suitable for display only at high zooms.
 * If either of `building=*` and `building:part` is `yes`, the `kind` property is dropped (and `kind:building` is implied).
 * Address points are `kind` of value `address`.
 
@@ -297,13 +297,13 @@ The `pois` layer should be used in conjuction with `landuse` (parks, etc) label_
 
 Points of interest from OpenStreetMap, with per-zoom selections similar to the primary [OSM.org Mapnik stylesheet](https://trac.openstreetmap.org/browser/subversion/applications/rendering/mapnik).
 
-Features from OpenStreetMap which are tagged `disused=*` for any other value than `disused=no` are not included in the data.
+Features from OpenStreetMap which are tagged `disused=*` for any other value than `disused=no` are not included in the data. Features which have certain parenthetical comments after their name are suppressed until zoom 17 and have their `kind` property set to that comment. Currently anything with a name ending in '(closed)' or '(historical)' will be suppressed in this manner.
 
 **POI properties (common):**
 
 * `name`
 * `id`: osm_id
-* `kind`: combination of the `aerialway`, `aeroway`, `amenity`, `attraction`, `barrier`, `craft`, `highway`, `historic`, `leisure`, `lock`, `man_made`, `natural`, `office`, `power`, `railway`, `rental`, `shop`, `tourism`, `waterway`, and `zoo` tags.
+* `kind`: combination of the `aerialway`, `aeroway`, `amenity`, `attraction`, `barrier`, `craft`, `highway`, `historic`, `leisure`, `lock`, `man_made`, `natural`, `office`, `power`, `railway`, `rental`, `shop`, `tourism`, `waterway`, and `zoo` tags. Can also be one of `closed` or `historical` if the original feature was parenthetically commented as closed or historical.
 
 Implied but not stated: `source`: `openstreetmap.org`.
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -403,3 +403,15 @@ post_process:
       source_layer: roads
       start_zoom: 8
       end_zoom: 16
+  - fn: TileStache.Goodies.VecTiles.transform.update_parenthetical_properties
+    params:
+      source_layer: pois
+      values: ['closed', 'historical']
+      target_min_zoom: 17
+      drop_below_zoom: 16
+  - fn: TileStache.Goodies.VecTiles.transform.update_parenthetical_properties
+    params:
+      source_layer: buildings
+      values: ['closed', 'historical']
+      target_min_zoom: 17
+      drop_below_zoom: 16

--- a/test/291-483-suppress-historical-closed.py
+++ b/test/291-483-suppress-historical-closed.py
@@ -1,0 +1,33 @@
+## Best buy (closed)
+
+# building should be present at z15
+assert_has_feature(
+    15, 5232, 12654, 'buildings',
+    {'id': 241643507, 'kind': 'retail'})
+
+# but POI shouldn't
+assert_no_matching_feature(
+    15, 5232, 12654, 'pois',
+    {'id': 241643507})
+
+# but POI should be present at z17 and marked as closed
+assert_has_feature(
+    17, 20931, 50616, 'pois',
+    {'id': 241643507, 'kind': 'closed', 'min_zoom': 17})
+
+## US Naval Hospital (historical)
+
+# original polygon should be present at z15
+assert_has_feature(
+    15, 5266, 12666, 'landuse',
+    {'id': -317369, 'kind': 'hospital'})
+
+# but POI should not be present
+assert_no_matching_feature(
+    15, 5266, 12666, 'pois',
+    {'id': -317369})
+
+# but it should be present at z17
+assert_has_feature(
+    17, 21063, 50665, 'pois',
+    {'id': -317369, 'kind': 'historical'})


### PR DESCRIPTION
Enable suppression of pois and buildings where they end with '(closed)' or '(historical)'.

Requires mapzen/TileStache#128. Connects to #291 and connects to #483.

@rmarianski could you review, please?