### PR TITLE
Drop physical railways from transit.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -457,7 +457,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_transit_level(route_val text)
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
-        CASE WHEN route_val IN ('train', 'railway') THEN 6
+        CASE WHEN route_val = 'train' THEN 6
              WHEN route_val IN ('subway', 'light_rail', 'tram') THEN 10
              ELSE NULL END
     );

--- a/data/migrations/v0.9.0-lines.sql
+++ b/data/migrations/v0.9.0-lines.sql
@@ -3,3 +3,8 @@ UPDATE planet_osm_line
     service, aerialway, leisure, sport, man_made, way)
   WHERE
     railway IN ('subway', 'funicular');
+
+UPDATE planet_osm_line
+  SET mz_transit_level = mz_calculate_transit_level(route)
+  WHERE
+    route = 'railway';

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -430,7 +430,7 @@ Railway values in this layer include: `rail`, `tram`, `light_rail`, `narrow_gaug
 * Layer name: `transit`
 * Geometry types: `line`, `polygon`
 
-Transit line features from OpenStreetMap start appearing at zoom 6+ for basic rail of `train`, and `railway`. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
+Transit line features from OpenStreetMap start appearing at zoom 6+ for basic rail kind of `train`. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
 
 _TIP: If you're looking for transit `station` and `station_entrance` features, look in the `pois` layer instead._
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -416,3 +416,8 @@ post_process:
       values: ['closed', 'historical']
       target_min_zoom: 17
       drop_below_zoom: 16
+  - fn: TileStache.Goodies.VecTiles.transform.merge_features
+    params:
+      source_layer: transit
+      start_zoom: 0
+      end_zoom: 15

--- a/test.py
+++ b/test.py
@@ -233,9 +233,15 @@ def assert_no_matching_feature(z, x, y, layer, properties):
             features, properties)
 
         if num_matching > 0:
-            raise Exception, "Found feature matching properties " \
-                "%r in layer %r, but was supposed to find none." \
-                % (properties, layer)
+            feature = None
+            for f in features:
+                if match_properties(f['properties'], properties):
+                    feature = f
+                    break
+
+            raise Exception, "Found feature matching properties %r in " \
+                "layer %r, but was supposed to find none. For example: " \
+                "%r" % (properties, layer, feature['properties'])
 
 
 def run_test(f, log, idx, num_tests):

--- a/test/501-drop-physical-railways-from-transit.py
+++ b/test/501-drop-physical-railways-from-transit.py
@@ -1,0 +1,18 @@
+assert_no_matching_feature(
+    7, 20, 48, 'transit',
+    {'kind': 'railway'})
+
+# count the unique parameters - there should only be one, indicating that the
+# rail routes have been merged.
+with features_in_tile_layer(7, 20, 48, 'transit') as transit:
+    seen_properties = set()
+    railway_kinds = set(['train', 'subway', 'light_rail', 'tram'])
+
+    for feature in transit:
+        if feature['properties'].get('kind') in railway_kinds:
+            props = frozenset(feature['properties'].items())
+            if props in seen_properties:
+                raise Exception("Duplicate properties %r in transit layer, but "
+                                "properties should be unique."
+                                % feature['properties'])
+            seen_properties.add(props)


### PR DESCRIPTION
Drop physical railways from `transit` layer. Merge geometry of remaining rail services / lines.

Connects to #501.

@rmarianski could you review, please?
