### PR TITLE
Categorize regional/national public transit trains

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -13,8 +13,8 @@ UPDATE planet_osm_line
   WHERE mz_calculate_road_level(highway, railway, aeroway, route, service, aerialway, leisure, sport, man_made, way) IS NOT NULL;
 
 UPDATE planet_osm_line
-  SET mz_transit_level = mz_calculate_transit_level(route)
-  WHERE mz_calculate_transit_level(route) IS NOT NULL;
+  SET mz_transit_level = mz_calculate_transit_level(route, service)
+  WHERE mz_calculate_transit_level(route, service) IS NOT NULL;
 
 CREATE INDEX planet_osm_line_waterway_index ON planet_osm_line(waterway) WHERE waterway IS NOT NULL;
 CREATE INDEX planet_osm_line_road_level_index ON planet_osm_line(mz_road_level) WHERE mz_road_level IS NOT NULL;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -164,11 +164,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION mz_calculate_transit_level(route_val text)
+CREATE OR REPLACE FUNCTION mz_calculate_transit_level(route_val text, service_val text)
 RETURNS SMALLINT AS $$
 BEGIN
     RETURN (
-        CASE WHEN route_val = 'train' THEN 6
+        CASE WHEN route_val = 'train'
+                  AND service_val IN ('high_speed', 'long_distance', 'international') THEN 5
+             WHEN route_val = 'train' THEN 6
              WHEN route_val = 'subway' THEN 8
              WHEN route_val IN ('light_rail', 'tram') THEN 9
              ELSE NULL END

--- a/data/migrations/v0.9.0-cleanup.sql
+++ b/data/migrations/v0.9.0-cleanup.sql
@@ -8,6 +8,8 @@ DROP FUNCTION IF EXISTS mz_calculate_is_landuse(text, text, text, text, text, te
 DROP FUNCTION IF EXISTS mz_calculate_is_landuse(text, text, text, text, text, text, text, text, text, text, hstore);
 DROP FUNCTION IF EXISTS mz_calculate_landuse_kind(text, text, text, text, text, text, text, text, text, text, hstore);
 
+DROP FUNCTION IF EXISTS mz_calculate_transit_level(text);
+
 ALTER TABLE planet_osm_polygon DROP COLUMN IF EXISTS mz_is_landuse;
 
 -- new queries don't use this function, so once the tilequeue/tileserver

--- a/data/migrations/v0.9.0-lines.sql
+++ b/data/migrations/v0.9.0-lines.sql
@@ -5,6 +5,7 @@ UPDATE planet_osm_line
     railway IN ('subway', 'funicular');
 
 UPDATE planet_osm_line
-  SET mz_transit_level = mz_calculate_transit_level(route)
+  SET mz_transit_level = mz_calculate_transit_level(route, service)
   WHERE
-    route IN ('railway', 'subway', 'light_rail', 'tram');
+    route IN ('railway', 'subway', 'light_rail', 'tram')
+    OR (route = 'train' AND service IN ('high_speed', 'long_distance', 'international'));

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -33,7 +33,7 @@ CREATE OR REPLACE FUNCTION mz_trigger_function_line()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.mz_road_level := mz_calculate_road_level(NEW."highway", NEW."railway", NEW."aeroway", NEW."route", NEW."service", NEW."aerialway", NEW."leisure", NEW."sport", NEW."man_made", NEW."way");
-    NEW.mz_transit_level := mz_calculate_transit_level(NEW."route");
+    NEW.mz_transit_level := mz_calculate_transit_level(NEW."route", NEW."service");
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -439,7 +439,7 @@ Railway values in this layer include: `rail`, `tram`, `light_rail`, `narrow_gaug
 * Layer name: `transit`
 * Geometry types: `line`, `polygon`
 
-Transit line features from OpenStreetMap start appearing at zoom 5+ for regional and national trains. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
+Transit line features from OpenStreetMap start appearing at zoom 5+ for national trains, with regional trains addded at zoom 6+. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
 
 _TIP: If you're looking for transit `station` and `station_entrance` features, look in the `pois` layer instead._
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -439,7 +439,7 @@ Railway values in this layer include: `rail`, `tram`, `light_rail`, `narrow_gaug
 * Layer name: `transit`
 * Geometry types: `line`, `polygon`
 
-Transit line features from OpenStreetMap start appearing at zoom 6+ for basic rail kind of `train`. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
+Transit line features from OpenStreetMap start appearing at zoom 5+ for regional and national trains. Then `subway`,`light_rail`, and `tram` are added at zoom 10+. Platform polygons are added zoom 14+.
 
 _TIP: If you're looking for transit `station` and `station_entrance` features, look in the `pois` layer instead._
 

--- a/queries/transit.jinja2
+++ b/queries/transit.jinja2
@@ -17,6 +17,7 @@ SELECT
     tags->'roundtrip' AS roundtrip,
     tags->'route_name' AS route_name,
     layer,
+    service,
     %#tags AS tags
 
 FROM planet_osm_line
@@ -48,10 +49,11 @@ SELECT
     tags->'roundtrip' AS roundtrip,
     tags->'route_name' AS route_name,
     layer,
+    service,
     %#tags AS tags
 
 FROM (
-  SELECT osm_id, way, name, ref, operator, route, railway, layer, tags
+  SELECT osm_id, way, name, ref, operator, route, railway, layer, service, tags
   FROM planet_osm_line
   WHERE
     {{ bounds|bbox_filter('way') }}
@@ -59,7 +61,7 @@ FROM (
 
   UNION ALL
 
-  SELECT osm_id, way, name, ref, operator, route, railway, layer, tags
+  SELECT osm_id, way, name, ref, operator, route, railway, layer, service, tags
   FROM planet_osm_polygon
   WHERE
     {{ bounds|bbox_filter('way') }}

--- a/test/471-categorize-trains.py
+++ b/test/471-categorize-trains.py
@@ -1,0 +1,14 @@
+# relation 2812900
+assert_has_feature(
+    5, 5, 12, 'transit',
+    { 'kind': 'train', 'service': 'long_distance' })
+
+# relation 4460896
+assert_has_feature(
+    5, 9, 12, 'transit',
+    { 'kind': 'train', 'service': 'high_speed' })
+
+# relation 4467189
+assert_has_feature(
+    5, 9, 12, 'transit',
+    { 'kind': 'train', 'service': 'international' })


### PR DESCRIPTION
Connects to #471

@zerebubuth, @nvkelso could you review please?

@nvkelso should we make a more specific sort_key entry for these national/regional trains compared to the other trains (without this service tag)?

I made a small update to the docs about when train features start appearing, but I didn't list the specific tag combinations for it. Could certainly update it to be more explicit if we want to do that.