### PR TITLE
Easier local migrations

### DIFF
--- a/data/migrations/create-sql-functions.py
+++ b/data/migrations/create-sql-functions.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from TileStache.Goodies.VecTiles.transform import _parse_kt
+import os.path
 import csv
 
 Rule = namedtuple(
@@ -156,11 +157,13 @@ def used_params(rules):
 
 
 layers = {}
+script_root = os.path.dirname(__file__)
 
 for layer in ('landuse', 'pois'):
     kind_rules = []
     min_zoom_rules = []
-    file_path = '../../spreadsheets/kind/%s.csv' % layer
+    csv_file = '../../spreadsheets/kind/%s.csv' % layer
+    file_path = os.path.join(script_root, csv_file)
     with open(file_path) as fh:
         reader = csv.reader(fh, skipinitialspace=True)
         keys = None
@@ -206,7 +209,7 @@ for layer in ('landuse', 'pois'):
         min_zoom_case_statement=min_zoom_case_statement,
     )
 
-template_name = 'sql.jinja2'
+template_name = os.path.join(script_root, 'sql.jinja2')
 environment = Environment(loader=FileSystemLoader('.'))
 template = environment.get_template(template_name)
 sql = template.render(

--- a/data/migrations/run_migrations.sh
+++ b/data/migrations/run_migrations.sh
@@ -22,7 +22,7 @@ done
 # are required by later steps.
 psql --set ON_ERROR_STOP=1 -f "${migration_dir}/../functions.sql" $*
 if [ $? -ne 0 ]; then echo "Installing new functions failed.">&2; exit 1; fi
-python create-sql-functions.py | psql --set ON_ERROR_STOP=1 $*
+python ${migration_dir}/create-sql-functions.py | psql --set ON_ERROR_STOP=1 $*
 if [ $? -ne 0 ]; then echo "Installing generated functions failed.">&2; exit 1; fi
 psql --set ON_ERROR_STOP=1 -f "${migration_dir}/../triggers.sql" $*
 if [ $? -ne 0 ]; then echo "Installing new triggers failed.">&2; exit 1; fi

--- a/data/migrations/v0.9.0-cleanup.sql
+++ b/data/migrations/v0.9.0-cleanup.sql
@@ -19,19 +19,65 @@ DROP FUNCTION IF EXISTS mz_calculate_transit_routes(bigint,bigint);
 
 BEGIN;
 
-DROP INDEX planet_osm_polygon_landuse_geom_9_index;
-ALTER INDEX new_planet_osm_polygon_landuse_geom_9_index RENAME TO planet_osm_polygon_landuse_geom_9_index;;
-DROP INDEX planet_osm_polygon_landuse_geom_12_index;
-ALTER INDEX new_planet_osm_polygon_landuse_geom_12_index RENAME TO planet_osm_polygon_landuse_geom_12_index;
-DROP INDEX planet_osm_polygon_landuse_geom_15_index;
-ALTER INDEX new_planet_osm_polygon_landuse_geom_15_index RENAME TO planet_osm_polygon_landuse_geom_15_index;
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_geom_9_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_geom_9_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_geom_9_index RENAME TO planet_osm_polygon_landuse_geom_9_index;
+END IF;
+END$$;
 
-DROP INDEX planet_osm_polygon_landuse_boundary_geom_4_index;
-ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_4_index RENAME TO planet_osm_polygon_landuse_boundary_geom_4_index;
-DROP INDEX planet_osm_polygon_landuse_boundary_geom_6_index;
-ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_6_index RENAME TO planet_osm_polygon_landuse_boundary_geom_6_index;
-DROP INDEX planet_osm_polygon_landuse_boundary_geom_8_index;
-ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_8_index RENAME TO planet_osm_polygon_landuse_boundary_geom_8_index;
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_geom_12_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_geom_12_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_geom_12_index RENAME TO planet_osm_polygon_landuse_geom_12_index;
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_geom_15_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_geom_15_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_geom_15_index RENAME TO planet_osm_polygon_landuse_geom_15_index;
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_boundary_geom_4_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_boundary_geom_4_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_4_index RENAME TO planet_osm_polygon_landuse_boundary_geom_4_index;
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_boundary_geom_6_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_boundary_geom_6_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_6_index RENAME TO planet_osm_polygon_landuse_boundary_geom_6_index;
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'new_planet_osm_polygon_landuse_boundary_geom_8_index'
+           AND n.nspname = 'public') THEN
+  DROP INDEX IF EXISTS planet_osm_polygon_landuse_boundary_geom_8_index;
+  ALTER INDEX new_planet_osm_polygon_landuse_boundary_geom_8_index RENAME TO planet_osm_polygon_landuse_boundary_geom_8_index;
+END IF;
+END$$;
 
 COMMIT;
 

--- a/data/migrations/v0.9.0-prune-toi.py
+++ b/data/migrations/v0.9.0-prune-toi.py
@@ -2,8 +2,14 @@ from redis import StrictRedis
 from tilequeue.cache import RedisCacheIndex
 from tilequeue.config import make_config_from_argparse
 from tilequeue.tile import coord_unmarshall_int
+import os.path
+import sys
 
-cfg = make_config_from_argparse('/etc/tilequeue/config.yaml')
+cfg_file = '/etc/tilequeue/config.yaml'
+if not os.path.exists(cfg_file):
+    sys.exit(0)
+
+cfg = make_config_from_argparse(cfg_file)
 redis_client = StrictRedis(cfg.redis_host)
 cache_index = RedisCacheIndex(redis_client)
 


### PR DESCRIPTION
A couple of changes which make it easier for me to run the migrations on my local machine:

1. I tend to run the migrations from within the root of the `vector-datasource/` dir, so I made the script independent of `$CWD`. It's just a convenience thing so I don't have to type `cd` twice... how lazy is that?
2. Made it so that the TOI prune script doesn't run if `/etc/tilequeue/config.yaml` doesn't exist, because it doesn't on my system. There might be a more clever way to figure out if there is a redis instance somewhere, but I figure most people running it locally won't have a TOI set.

@rmarianski could you review, please?