### PR TITLE
Add bus route property.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -366,6 +366,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `ferry`: See kind list below.
 * `highway`: See kind list below.
 * `is_bridge`: `yes` or `no`
+* `is_bus_route`: If present and `true`, then buses travel down this road. This property is determined based on whether the road is part of an OSM bus route relation.
 * `is_link`: `yes` or `no`
 * `is_tunnel`: `yes` or `no`
 * `leisure`: See kind list below.

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -68,6 +68,14 @@ SELECT
     leisure,
     sport,
     man_made,
+{% if zoom >= 11 %}
+    -- try to only calculate whether this is a bus route when we already know
+    -- that it's a road, as joining onto the rels table can be expensive.
+    CASE WHEN mz_calculate_highway_level(highway, service) IS NOT NULL
+      THEN mz_calculate_is_bus_route(osm_id)
+      ELSE NULL
+    END AS is_bus_route,
+{% endif %}
     %#tags AS tags
 
 FROM planet_osm_line
@@ -127,6 +135,7 @@ SELECT
     leisure,
     sport,
     man_made,
+    NULL AS is_bus_route,
     %#tags AS tags
 
 FROM planet_osm_line


### PR DESCRIPTION
Adds a new property `is_bus_route` on roads to indicate if they are members of bus route relations.

Connects to #611.

@rmarianski could you review, please?