### PR TITLE
Normalize ne kinds and admin_levels

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -108,13 +108,11 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 
 ![image](images/mapzen-vector-tile-docs-barriers.png)
 
-**Gotchas:** Boundary `kind` values are not yet normalized between OpenStreetMap and Natural Earth. See Boundary kind values (line) gotchas section below for more detail.
-
 **Boundary properties (common):**
 
 * `name`
 * `id`
-* `kind`: mapping of OpenStreetMap's `admin_level` int values to strings like `country` and `state`, plus `aboriginal_lands` boundary type, and inclusive of some barrier and man_made tags: `city_wall` (zoom 12+), `retaining_wall`, `snow_fence` (zoom 15+), and `fence` (zoom 16+ only). Also includes raw Natural Earth values.
+* `kind`: mapping of OpenStreetMap's `admin_level` int values to strings like `country` and `state`, plus `aboriginal_lands` boundary type, and inclusive of some barrier and man_made tags: `city_wall` (zoom 12+), `retaining_wall`, `snow_fence` (zoom 15+), and `fence` (zoom 16+ only).
 * `sort_key`: a suggestion for which order to draw features. The value is an integer where smaller numbers suggest that features should be "behind" features with larger numbers.
 
 **Boundary properties (common optional):**
@@ -125,7 +123,6 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 * `name:left`: See name section above, other variants like `old_name` also supported.
 * `name:right`: See name section above, other variants like `old_name` also supported.
 * `maritime_boundary`: a special Mapzen calculated value loosely coupled with OpenStreetMap's maritime tag, but with spatial buffer processing for lines falling in the ocean.
-* `type`: required at zooms less than 8 coming from Natural Earth for country and state (zoom 2+) boundaries, roughly equivalent to OSM's `admin_level` values.
 
 **Boundary properties (optional):**
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -136,6 +136,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.tags_create_dict
       - TileStache.Goodies.VecTiles.transform.tags_name_i18n
       - TileStache.Goodies.VecTiles.transform.tags_remove
+      - TileStache.Goodies.VecTiles.transform.admin_level_as_int
       - TileStache.Goodies.VecTiles.transform.boundary_kind
       - TileStache.Goodies.VecTiles.transform.add_id_to_properties
       - TileStache.Goodies.VecTiles.transform.detect_osm_relation

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -2,8 +2,14 @@
     gid AS __id__,
     {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
     scalerank::float,
-    featurecla AS kind,
-    '{{ type }}' AS type
+    '{{ type }}' AS kind,
+{% if type == 'country' %}
+    2 AS admin_level
+{% elif type == 'state' %}
+    4 AS admin_level
+{% else %}
+    NULL AS admin_level
+{% endif %}
 {% endmacro %}
 
 {% if zoom < 2 %}

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -60,6 +60,7 @@ FROM
     ne_10m_admin_1_states_provinces_lines
 WHERE
     {{ bounds|bbox_filter('the_geom') }}
+    AND featurecla NOT IN ('Admin-1 statistical boundary', 'Admin-1 statistical meta bounds');
 
 {% else %}
 

--- a/spreadsheets/boundaries.csv
+++ b/spreadsheets/boundaries.csv
@@ -1,19 +1,8 @@
 kind,sort_key
 municipality,252
 county,254
-Admin-1 boundary,256
 state,256
-1st Order Admin Line,256
-Admin-1 region boundary,257
-Indefinite (please verify),259
-Indeterminant frontier,259
-Lease limit,259
-Overlay limit,259
-Line of control (please verify),260
-Disputed (please verify),261
-Admin-0 country,262
 country,262
-International boundary (verify),262
 city_wall,264
 retaining_wall,265
 snow_fence,266

--- a/test/517-normalize-ne-boundary-kinds.py
+++ b/test/517-normalize-ne-boundary-kinds.py
@@ -1,0 +1,7 @@
+assert_has_feature(
+    1, 1, 1, 'boundaries',
+    { 'kind': 'country', 'admin_level': 2 })
+
+assert_has_feature(
+    7, 37, 48, 'boundaries',
+    { 'kind': 'state', 'admin_level': 4 })


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/517

I'm including admin_level as an integer. It looks like the admin_level that we include from osm will be returned back as a string though. Should we also ensure that the admin_level value is always an integer?

@nvkelso, @zerebubuth could you review please?