### PR TITLE
fixes #593 for early paths

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -42,10 +42,10 @@ BEGIN
     WHEN highway_val IN ('secondary')                                         THEN 10
     WHEN highway_val IN ('motorway_link', 'tertiary')                         THEN 11
     WHEN highway_val IN ('trunk_link', 'residential', 'unclassified', 'road') THEN 12
-    WHEN highway_val IN ('primary_link', 'secondary_link', 'track',
-                         'pedestrian', 'living_street', 'path')               THEN 13
-    WHEN highway_val IN ('tertiary_link', 'minor', 'footpath', 'footway',
-                         'steps', 'cycleway')                                 THEN 14
+    WHEN highway_val IN ('primary_link', 'secondary_link',
+                         'pedestrian', 'living_street', 'track',
+                         'path', 'footway', 'steps', 'cycleway')              THEN 13
+    WHEN highway_val IN ('tertiary_link')                                     THEN 14
     WHEN highway_val = 'service' THEN CASE
       WHEN service_val IS NULL                                                THEN 14
       WHEN service_val = 'alley'                                              THEN 13

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -692,8 +692,8 @@ BEGIN
     SELECT
         MIN(
             CASE WHEN hstore(tags)->'network' IN ('iwn','nwn') THEN 11
-                WHEN hstore(tags)->'network' IN ('rwn') THEN 12
-                WHEN hstore(tags)->'network' IN ('lwn') THEN 13
+                 WHEN hstore(tags)->'network' IN ('rwn') THEN 12
+                 WHEN hstore(tags)->'network' IN ('lwn') THEN 13
             ELSE NULL
             END
         )

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -43,9 +43,9 @@ BEGIN
     WHEN highway_val IN ('motorway_link', 'tertiary')                         THEN 11
     WHEN highway_val IN ('trunk_link', 'residential', 'unclassified', 'road') THEN 12
     WHEN highway_val IN ('primary_link', 'secondary_link', 'track',
-                         'pedestrian', 'living_street')                       THEN 13
+                         'pedestrian', 'living_street', 'path')               THEN 13
     WHEN highway_val IN ('tertiary_link', 'minor', 'footpath', 'footway',
-                         'steps', 'path', 'cycleway')                         THEN 14
+                         'steps', 'cycleway')                                 THEN 14
     WHEN highway_val = 'service' THEN CASE
       WHEN service_val IS NULL                                                THEN 14
       WHEN service_val = 'alley'                                              THEN 13

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -681,6 +681,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
+CREATE OR REPLACE FUNCTION mz_is_path_major_route_relation(tags hstore)
+RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN (
+      tags->'type' = 'route' AND
+      tags->'route' IN ('hiking', 'foot') AND
+      tags->'network' IN ('iwn','nwn','rwn','lwn')
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
 -- returns TRUE if the given way ID (osm_id) is part of a path route relation,
 -- or NULL otherwise.
 -- This function is meant to be called for something that we already know is a path.
@@ -702,9 +713,8 @@ BEGIN
     WHERE
       parts && ARRAY[osm_id] AND
       parts[way_off+1:rel_off] && ARRAY[osm_id] AND
-      hstore(tags)->'type' = 'route' AND
-      hstore(tags)->'route' IN ('hiking', 'foot') AND
-      hstore(tags)->'network' IN ('iwn','nwn','rwn','lwn'));
+      mz_is_path_major_route_relation(hstore(tags))
+  );
 END;
 $$ LANGUAGE plpgsql STABLE;
 

--- a/data/migrations/v0.10.0-line.sql
+++ b/data/migrations/v0.10.0-line.sql
@@ -1,6 +1,12 @@
 UPDATE planet_osm_line
-SET mz_water_min_zoom = mz_calculate_min_zoom_water(planet_osm_line.*)
-WHERE mz_calculate_min_zoom_water(planet_osm_line.*) IS NOT NULL;
+  SET mz_water_min_zoom = mz_calculate_min_zoom_water(planet_osm_line.*)
+  WHERE mz_calculate_min_zoom_water(planet_osm_line.*) IS NOT NULL;
+
+UPDATE planet_osm_line
+  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route,
+    service, aerialway, leisure, sport, man_made, way)
+  WHERE
+    highway = 'path';
 
 CREATE INDEX new_planet_osm_line_water_geom_9_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 9;
 CREATE INDEX new_planet_osm_line_water_geom_12_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 12;
@@ -27,3 +33,4 @@ BEGIN;
   ALTER INDEX new_planet_osm_line_boundary_geom_12_index RENAME TO planet_osm_line_boundary_geom_12_index;
   ALTER INDEX new_planet_osm_line_boundary_geom_15_index RENAME TO planet_osm_line_boundary_geom_15_index;
 COMMIT;
+

--- a/data/migrations/v0.10.0-line.sql
+++ b/data/migrations/v0.10.0-line.sql
@@ -3,10 +3,9 @@ UPDATE planet_osm_line
   WHERE mz_calculate_min_zoom_water(planet_osm_line.*) IS NOT NULL;
 
 UPDATE planet_osm_line
-  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route,
-    service, aerialway, leisure, sport, man_made, way)
+  SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route, service, aerialway, leisure, sport, man_made, way, name, bicycle, foot, horse, tags->'snowmobile', tags->'ski', osm_id)
   WHERE
-    highway IN ('path', 'footpath', 'footway', 'steps', 'cycleway', 'minor');
+    highway IN ('path', 'footway', 'steps', 'footpath', 'minor');
 
 CREATE INDEX new_planet_osm_line_water_geom_9_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 9;
 CREATE INDEX new_planet_osm_line_water_geom_12_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 12;

--- a/data/migrations/v0.10.0-line.sql
+++ b/data/migrations/v0.10.0-line.sql
@@ -6,7 +6,7 @@ UPDATE planet_osm_line
   SET mz_road_level = mz_calculate_road_level(highway, railway, aeroway, route,
     service, aerialway, leisure, sport, man_made, way)
   WHERE
-    highway = 'path';
+    highway IN ('path', 'footpath', 'footway', 'steps', 'cycleway', 'minor');
 
 CREATE INDEX new_planet_osm_line_water_geom_9_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 9;
 CREATE INDEX new_planet_osm_line_water_geom_12_index ON planet_osm_line USING gist(way) WHERE mz_water_min_zoom <= 12;
@@ -33,4 +33,3 @@ BEGIN;
   ALTER INDEX new_planet_osm_line_boundary_geom_12_index RENAME TO planet_osm_line_boundary_geom_12_index;
   ALTER INDEX new_planet_osm_line_boundary_geom_15_index RENAME TO planet_osm_line_boundary_geom_15_index;
 COMMIT;
-

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -37,7 +37,7 @@ COMMIT;
 CREATE OR REPLACE FUNCTION mz_trigger_function_line()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.mz_road_level := mz_calculate_road_level(NEW."highway", NEW."railway", NEW."aeroway", NEW."route", NEW."service", NEW."aerialway", NEW."leisure", NEW."sport", NEW."man_made", NEW."way");
+    NEW.mz_road_level := mz_calculate_road_level(NEW."highway", NEW."railway", NEW."aeroway", NEW."route", NEW."service", NEW."aerialway", NEW."leisure", NEW."sport", NEW."man_made", NEW."way", NEW."name", NEW."bicycle", NEW."foot", NEW."horse", NEW.tags->'snowmobile', NEW.tags->'ski', NEW.osm_id);
     NEW.mz_transit_level := mz_calculate_min_zoom_transit(NEW.*);
     NEW.mz_water_min_zoom := mz_calculate_min_zoom_water(NEW.*);
     NEW.mz_boundary_min_zoom := mz_calculate_min_zoom_boundaries(NEW.*);

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -51,3 +51,23 @@ BEGIN;
 DROP TRIGGER IF EXISTS mz_trigger_line ON planet_osm_line;
 CREATE TRIGGER mz_trigger_line BEFORE INSERT OR UPDATE ON planet_osm_line FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_line();
 COMMIT;
+
+CREATE OR REPLACE FUNCTION mz_trigger_function_osm_rels()
+RETURNS TRIGGER AS $$
+DECLARE
+  is_old_path_major_route_relation bool := mz_is_path_major_route_relation(hstore(OLD.tags));
+  is_new_path_major_route_relation bool := mz_is_path_major_route_relation(hstore(NEW.tags));
+  old_way_ids bigint[] := CASE WHEN is_old_path_major_route_relation THEN OLD.parts[OLD.way_off+1:OLD.rel_off] ELSE ARRAY[]::bigint[] END;
+  new_way_ids bigint[] := CASE WHEN is_new_path_major_route_relation THEN NEW.parts[NEW.way_off+1:NEW.rel_off] ELSE ARRAY[]::bigint[] END;
+BEGIN
+  UPDATE planet_osm_line
+    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id)
+    WHERE (array[osm_id] <@ old_way_ids) <> (array[osm_id] <@ new_way_ids);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+BEGIN;
+DROP TRIGGER IF EXISTS mz_trigger_osm_rels ON planet_osm_rels;
+CREATE TRIGGER mz_trigger_osm_rels BEFORE INSERT OR UPDATE ON planet_osm_rels FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_osm_rels();
+COMMIT;

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -69,5 +69,5 @@ $$ LANGUAGE plpgsql VOLATILE;
 
 BEGIN;
 DROP TRIGGER IF EXISTS mz_trigger_osm_rels ON planet_osm_rels;
-CREATE TRIGGER mz_trigger_osm_rels BEFORE INSERT OR UPDATE ON planet_osm_rels FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_osm_rels();
+CREATE TRIGGER mz_trigger_osm_rels AFTER INSERT OR UPDATE OR DELETE ON planet_osm_rels FOR EACH ROW EXECUTE PROCEDURE mz_trigger_function_osm_rels();
 COMMIT;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -418,7 +418,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 
 ### Transportation kind values and zoom ranges
 
-**Roads** from **OpenStreetMap** are shown starting at zoom 8 with `motorway`, `trunk`, `primary`. `secondary` are added starting at zoom 10, with `motorway_link`, `tertiary` added at zoom 11. Zoom 12 sees addition of `trunk_link`, `residential`, `unclassified`, `road`). Zoom 13 adds (`primary_link`, `secondary_link`, `track`, `pedestrian`, `living_street`). Zoom 14 adds (`tertiary_link`, `minor`, `footpath`, `footway`, `steps`, `path`, `cycleway`) and `alley` service roads. By zoom 15 all service roads are added, including driveway, `parking_aisle`, `drive-through`.
+**Roads** from **OpenStreetMap** are shown starting at zoom 8 with `motorway`, `trunk`, `primary`. `secondary` are added starting at zoom 10, with `motorway_link`, `tertiary` added at zoom 11. Zoom 12 sees addition of `trunk_link`, `residential`, `unclassified`, and `road`, and internationally and nationally significant paths (`path`, `footway`, `steps`). Zoom 13 adds `primary_link`, `secondary_link`, `track`, `pedestrian`, `living_street`, and  `cycleway` and regionally significant and/or named or designated paths. Zoom 14 adds `tertiary_link`, all remaining `path`, `footway`, and `steps`, and `alley` service roads. By zoom 15 all remaining service roads are added, including `driveway`, `parking_aisle`, `drive-through`.
 
 **Roads** from **Natural Earth**  are used at low zooms below 8. Road `kind` values are limited to `Road` and `Ferry` at these zooms. It's more useful to look at `type` values: `Beltway`, `Bypass`, `Ferry Route`, `Ferry, seasonal`, `Major Highway`, `Road`, `Secondary Highway`, `Track`, and `Unknown`.
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -382,7 +382,7 @@ post_process:
       end_zoom: 16
       properties: [name, ref, network]
       where: >-
-        (kind == 'path' and zoom < 16) or
+        (kind == 'path' and zoom < 14) or
         (kind == 'rail' and zoom < 15) or
         (kind == 'minor_road' and zoom < 14) or
         (kind == 'major_road' and zoom <  7) or

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -71,7 +71,10 @@ SELECT
 {% if zoom >= 12 %}
     -- try to only calculate whether this is a bus route when we already know
     -- that it's a road, as joining onto the rels table can be expensive.
-    CASE WHEN mz_calculate_highway_level(highway, service) IS NOT NULL
+    CASE WHEN highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link',
+                          'primary', 'primary_link', 'secondary', 'secondary_link',
+                          'tertiary', 'tertiary_link',
+                          'residential', 'unclassified', 'road', 'living_street')
       THEN mz_calculate_is_bus_route(osm_id)
       ELSE NULL
     END AS is_bus_route,

--- a/spreadsheets/roads.csv
+++ b/spreadsheets/roads.csv
@@ -23,8 +23,8 @@ zoom::int,layer::int,kind,highway,type,railway,aeroway,service,aerialway,is_brid
 >=15,-,minor_road,*,*,*,taxiway,*,*,yes,-,426
 >=15,-,highway,motorway_link;trunk_link;primary_link;secondary_link;tertiary_link,*,*,*,*,*,yes,-,425
 >=15,-,minor_road,residential;unclassified;road;living_street,*,*,*,*,*,yes,-,410
->=15,-,minor_road,service;minor,*,*,*,-,*,yes,-,408
->=15,-,minor_road,service;minor,*,*,*,*,*,yes,-,406
+>=15,-,minor_road,service,*,*,*,-,*,yes,-,408
+>=15,-,minor_road,service,*,*,*,*,*,yes,-,406
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,spur;siding,*,yes,-,411
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,yard,*,yes,-,409
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,+,*,yes,-,407
@@ -40,8 +40,8 @@ zoom::int,layer::int,kind,highway,type,railway,aeroway,service,aerialway,is_brid
 >=15,-,minor_road,*,*,*,taxiway,*,*,-,yes,326
 >=15,-,highway,motorway_link;trunk_link;primary_link;secondary_link;tertiary_link,*,*,*,*,*,-,yes,325
 >=15,-,minor_road,residential;unclassified;road;living_street,*,*,*,*,*,-,yes,310
->=15,-,minor_road,service;minor,*,*,*,-,*,-,yes,308
->=15,-,minor_road,service;minor,*,*,*,*,*,-,yes,306
+>=15,-,minor_road,service,*,*,*,-,*,-,yes,308
+>=15,-,minor_road,service,*,*,*,*,*,-,yes,306
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,spur;siding,*,-,yes,311
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,yard,*,-,yes,309
 >=15,-,rail,*,*,rail;tram;light_rail;narrow_gauge;monorail;subway;funicular,*,+,*,-,yes,307
@@ -62,8 +62,8 @@ zoom::int,layer::int,kind,highway,type,railway,aeroway,service,aerialway,is_brid
 *,*,highway,motorway_link;trunk_link;primary_link;secondary_link;tertiary_link,*,*,*,*,*,*,*,375
 *,*,minor_road,residential;unclassified;road;living_street,*,*,*,*,*,*,*,360
 *,*,*,*,Unknown,*,*,*,*,*,*,360
-*,*,minor_road,service;minor,*,*,*,-,*,*,*,358
-*,*,minor_road,service;minor,*,*,*,*,*,*,*,356
+*,*,minor_road,service,*,*,*,-,*,*,*,358
+*,*,minor_road,service,*,*,*,*,*,*,*,356
 *,*,aerialway,*,*,*,*,*,gondola;cable_car,*,*,442
 *,*,aerialway,*,*,*,*,*,chair_lift,*,*,441
 *,*,aerialway,*,*,*,*,*,+,*,*,440

--- a/test/593-early-footway.py
+++ b/test/593-early-footway.py
@@ -1,0 +1,15 @@
+tiles = [
+    [11, 344, 790],     # way 83076573   highway=footway, no name, route national (Pacific Crest Trail)
+    [11, 345, 790],     # way 372066789  highway=footway, no name, route national (Pacific Crest Trail)
+    [12, 654, 1582],    # way 239141479  highway=footway, with name, and route regional (Rodeo Valley Trail, Marin)
+    [13, 1308, 3167],   # way 161702316  highway=footway, with designation (Ocean Beach north, SF)
+    [13, 1308, 3166],   # way 28691787   highway=footway, with designation (Ocean Beach south, SF)
+    [13, 1308, 3164],   # way 24526324   highway=footway, with name (Coastal Trail, Marin)
+    [13, 1308, 3166],   # way 27553452   highway=footway, with name (Coastal Trail, SF)
+    [13, 1309, 3165]    # way 69020102   highway=footway, with name (Lovers Lane, SF)
+]
+
+for z, x, y in tiles:
+    assert_has_feature(
+        z, x, y, 'roads',
+        {'highway': 'footway'})

--- a/test/593-early-path.py
+++ b/test/593-early-path.py
@@ -1,0 +1,11 @@
+tiles = [
+    [11, 345, 790],     # way 236361475  highway=path, with route national (Pacific Crest Trail)
+    [12, 687, 1584],    # way 373491941  highway=path, with route regional (Merced Pass Trail)
+    [12, 688, 1584],    # way 39996451   highway=path, with route regional (Merced Pass Trail)
+    [13, 1374, 3166]   # way 162322353  highway=path, no route, but has name (Upper Yosemite Falls Trail)
+]
+
+for z, x, y in tiles:
+    assert_has_feature(
+        z, x, y, 'roads',
+        {'highway': 'path'})

--- a/test/593-early-step.py
+++ b/test/593-early-step.py
@@ -1,0 +1,10 @@
+tiles = [
+    [12,  653, 1582],   # way 24655593   highway=steps, with route regional (Coastal Trail, Marin, II)
+    [13, 1309, 3166],   # way 38060491   highway=steps, no route, but has name, and designation (Levant St Stairway, SF)
+    [13, 1310, 3167]    # way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
+]
+
+for z, x, y in tiles:
+    assert_has_feature(
+        z, x, y, 'roads',
+        {'highway': 'steps'})


### PR DESCRIPTION
* connects to #593 by moving many "path" like ways to zoom 13 and even zoom 12 and 11 depending on their significance. 
* restore names on paths at zooms 14 and z15
* remove bogus highway=minor and highway=footpath
* [tests] add tests for early zoom highway=path, =footway, =step
* [docs]  update layer reference to indicate earlier zooms for select paths;