### PR TITLE
Fix trigger update performance

### DIFF
--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -64,7 +64,9 @@ DECLARE
 BEGIN
   UPDATE planet_osm_line
     SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
-    WHERE (array[osm_id] <@ old_way_ids) <> (array[osm_id] <@ new_way_ids);
+    WHERE
+      (osm_id = ANY(new_way_ids) AND NOT osm_id = ANY(old_way_ids)) OR
+      (osm_id = ANY(old_way_ids) AND NOT osm_id = ANY(new_way_ids));
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
@@ -77,7 +79,7 @@ DECLARE
 BEGIN
   UPDATE planet_osm_line
     SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
-    WHERE (array[osm_id] <@ new_way_ids);
+    WHERE osm_id = ANY(new_way_ids);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
@@ -90,7 +92,7 @@ DECLARE
 BEGIN
   UPDATE planet_osm_line
     SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
-    WHERE (array[osm_id] <@ old_way_ids);
+    WHERE osm_id = ANY(old_way_ids);
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/data/triggers.sql
+++ b/data/triggers.sql
@@ -63,7 +63,7 @@ DECLARE
   new_way_ids bigint[] := CASE WHEN is_new_path_major_route_relation THEN NEW.parts[NEW.way_off+1:NEW.rel_off] ELSE ARRAY[]::bigint[] END;
 BEGIN
   UPDATE planet_osm_line
-    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id)
+    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
     WHERE (array[osm_id] <@ old_way_ids) <> (array[osm_id] <@ new_way_ids);
   RETURN NEW;
 END;
@@ -76,7 +76,7 @@ DECLARE
   new_way_ids bigint[] := CASE WHEN is_new_path_major_route_relation THEN NEW.parts[NEW.way_off+1:NEW.rel_off] ELSE ARRAY[]::bigint[] END;
 BEGIN
   UPDATE planet_osm_line
-    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id)
+    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
     WHERE (array[osm_id] <@ new_way_ids);
     RETURN NEW;
 END;
@@ -89,7 +89,7 @@ DECLARE
   old_way_ids bigint[] := CASE WHEN is_old_path_major_route_relation THEN OLD.parts[OLD.way_off+1:OLD.rel_off] ELSE ARRAY[]::bigint[] END;
 BEGIN
   UPDATE planet_osm_line
-    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id)
+    SET mz_road_level = mz_calculate_road_level("highway", "railway", "aeroway", "route", "service", "aerialway", "leisure", "sport", "man_made", "way", "name", "bicycle", "foot", "horse", tags->'snowmobile', tags->'ski', osm_id, tags->'whitewater')
     WHERE (array[osm_id] <@ old_way_ids);
     RETURN NULL;
 END;


### PR DESCRIPTION
Instead of using array subset operations, which Postgres doesn't appear to be able to use the btree index for, use the `ANY` keyword, which does appear to use the index. The `WHERE` clauses aren't quite so easy to read, but it results in much better query plans against my local database.

Connects to #593.

@rmarianski could you review, please?