### PR TITLE
add ranger stations

### DIFF
--- a/data/migrations/v0.10.0-point.sql
+++ b/data/migrations/v0.10.0-point.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_point
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_point.*)
 WHERE
-  amenity = 'boat_rental' OR
+  amenity = ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/data/migrations/v0.10.0-polygon.sql
+++ b/data/migrations/v0.10.0-polygon.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_polygon
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_polygon.*)
 WHERE
-  amenity = 'boat_rental' OR
+  amenity = ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/data/migrations/v0.10.0-polygon.sql
+++ b/data/migrations/v0.10.0-polygon.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_polygon
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_polygon.*)
 WHERE
-  amenity = ('boat_rental', 'ranger_station') OR
+  amenity IN ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -676,6 +676,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `pub`
 * `put_in_egress`
 * `put_in`
+* `ranger_station`
 * `rapid`
 * `recycling`
 * `refugee_camp`

--- a/test/671-ranger-station.py
+++ b/test/671-ranger-station.py
@@ -1,0 +1,26 @@
+#http://www.openstreetmap.org/node/1996636138
+# Big Basin Redwoods State Park Headquarters
+# Node with amenity=ranger_station, but also has tourism=information set
+assert_has_feature(
+    14, 2629, 6367, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#https://www.openstreetmap.org/node/351892607
+# Pantoll Ranger Station
+# Node with amenity=ranger_station, but also has tourism=information set
+assert_has_feature(
+    14, 2612, 6325, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#http://www.openstreetmap.org/way/361301773
+# Building with amenity=ranger_station
+assert_has_feature(
+    14, 2617, 6329, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#https://www.openstreetmap.org/way/269908344
+# Entrance Yosemite Nationalpark
+# Building with amenity=ranger_station
+assert_has_feature(
+    14, 2742, 6337, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -328,6 +328,9 @@ filters:
   - filter: {natural: tree}
     min_zoom: 16
     output: {kind: tree}
+  - filter: {amenity: ranger_station}
+    min_zoom: 14
+    output: {kind: ranger_station}
   - filter:
       tourism: [camp_site, caravan_site, information, viewpoint]
     min_zoom: 16


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/671. 

Should be merged after https://github.com/mapzen/vector-datasource/pull/714 to take advantage of reformatted doc kind listing.

* add ranger_station to POIs layer selection
* [test] add ranger station
* [docs] add ranger station to POI kind list
* [migration] add ranger_station amenity migration