### PR TITLE
add outdoor man_made landmarks

### DIFF
--- a/data/migrations/v0.10.0-point.sql
+++ b/data/migrations/v0.10.0-point.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_point
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_point.*)
 WHERE
-  amenity = 'boat_rental' OR
+  amenity = ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/data/migrations/v0.10.0-point.sql
+++ b/data/migrations/v0.10.0-point.sql
@@ -5,7 +5,7 @@ WHERE
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR
-  man_made IN ('beacon', 'cross', 'mineshaft', 'adit', 'water_well') OR
+  man_made IN ('beacon', 'cross', 'mineshaft', 'adit', 'water_well', 'communications_tower', 'observatory', 'telescope', 'offshore_platform', 'water_tower', 'mast') OR
   "natural" IN ('saddle', 'dune', 'geyser', 'sinkhole', 'hot_spring', 'rock', 'stone') OR
   highway = 'trailhead' OR
   tags->'whitewater' IN ('put_in;egress', 'put_in', 'egress', 'hazard', 'rapid');

--- a/data/migrations/v0.10.0-polygon.sql
+++ b/data/migrations/v0.10.0-polygon.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_polygon
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_polygon.*)
 WHERE
-  amenity = 'boat_rental' OR
+  amenity = ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/data/migrations/v0.10.0-polygon.sql
+++ b/data/migrations/v0.10.0-polygon.sql
@@ -5,7 +5,7 @@ WHERE
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR
-  man_made IN ('beacon', 'cross', 'mineshaft', 'adit', 'water_well') OR
+  man_made IN ('beacon', 'cross', 'mineshaft', 'adit', 'water_well', 'communications_tower', 'observatory', 'telescope', 'offshore_platform', 'water_tower', 'mast') OR
   "natural" IN ('saddle', 'dune', 'geyser', 'sinkhole', 'hot_spring', 'rock', 'stone') OR
   highway = 'trailhead' OR
   tags->'whitewater' IN ('put_in;egress', 'put_in', 'egress', 'hazard', 'rapid');

--- a/data/migrations/v0.10.0-polygon.sql
+++ b/data/migrations/v0.10.0-polygon.sql
@@ -1,7 +1,7 @@
 UPDATE planet_osm_polygon
 SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_polygon.*)
 WHERE
-  amenity = ('boat_rental', 'ranger_station') OR
+  amenity IN ('boat_rental', 'ranger_station') OR
   shop IN ('boat_rental', 'fishing', 'hunting', 'outdoor', 'scuba_diving', 'gas', 'motorcycle') OR
   tags->'rental' = 'boat' OR
   (shop = 'boat' AND tags->'rental' = 'yes') OR

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -550,6 +550,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `clothes`
 * `club`
 * `college`
+* `communications_tower`
 * `community_centre`
 * `company`
 * `computer`
@@ -651,6 +652,8 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `nursing_home`
 * `optician`
 * `outdoor`
+* `observatory`
+* `offshore_platform`
 * `outreach`
 * `painter`
 * `parking`
@@ -716,6 +719,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `tax_advisor`
 * `telecommunication`
 * `telephone`
+* `telescope`
 * `theatre`
 * `theme_park`
 * `therapist`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -676,6 +676,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `pub`
 * `put_in_egress`
 * `put_in`
+* `ranger_station`
 * `rapid`
 * `recycling`
 * `refugee_camp`

--- a/test/671-ranger-station.py
+++ b/test/671-ranger-station.py
@@ -1,0 +1,26 @@
+#http://www.openstreetmap.org/node/1996636138
+# Big Basin Redwoods State Park Headquarters
+# Node with amenity=ranger_station, but also has tourism=information set
+assert_has_feature(
+    14, 2629, 6367, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#https://www.openstreetmap.org/node/351892607
+# Pantoll Ranger Station
+# Node with amenity=ranger_station, but also has tourism=information set
+assert_has_feature(
+    14, 2612, 6325, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#http://www.openstreetmap.org/way/361301773
+# Building with amenity=ranger_station
+assert_has_feature(
+    14, 2617, 6329, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })
+
+#https://www.openstreetmap.org/way/269908344
+# Entrance Yosemite Nationalpark
+# Building with amenity=ranger_station
+assert_has_feature(
+    14, 2742, 6337, 'pois',
+    { 'kind': 'ranger_station', 'min_zoom': 14 })

--- a/test/675-man_made-outdoor-landmarks.py
+++ b/test/675-man_made-outdoor-landmarks.py
@@ -1,0 +1,49 @@
+#http://www.openstreetmap.org/node/1230069003
+assert_has_feature(
+    15, 5285, 12654, 'pois',
+    { 'kind': 'communications_tower', 'min_zoom': 15 })
+
+#http://www.openstreetmap.org/node/747693102
+# ideally the landuse would show up at zoom 13, but that's sparse coverage
+# most features are buildings, some of which are incorrectly tagged (should be telescope)
+assert_has_feature(
+    15, 9504, 12490, 'pois',
+    { 'kind': 'observatory', 'min_zoom': 15 })
+
+#http://www.openstreetmap.org/node/258205070
+assert_has_feature(
+    16, 10623, 25430, 'pois',
+    { 'kind': 'telescope', 'min_zoom': 16 })
+
+#http://www.openstreetmap.org/way/258205070
+# If someone took the time to digitize a building, promote it up
+assert_has_feature(
+    15, 5324, 12781, 'pois',
+    { 'kind': 'telescope', 'min_zoom': 15 })
+
+#http://www.openstreetmap.org/node/2622856034
+assert_has_feature(
+    13, 1409, 3281, 'pois',
+    { 'kind': 'offshore_platform', 'min_zoom': 13 })
+
+#http://www.openstreetmap.org/way/346405529
+assert_has_feature(
+    13, 1367, 3261, 'pois',
+    { 'kind': 'offshore_platform', 'min_zoom': 13 })
+
+#http://www.openstreetmap.org/way/350328482
+assert_has_feature(
+    13, 1942, 3395, 'pois',
+    { 'kind': 'offshore_platform', 'min_zoom': 13 })
+
+#http://www.openstreetmap.org/node/1501843094
+assert_has_feature(
+    15, 5240, 12673, 'pois',
+    { 'kind': 'water_tower', 'min_zoom': 15 })
+
+#http://www.openstreetmap.org/node/1501843094
+# This isn't part of the work, but because we split water_tower 
+# off from mast, we should test mast still shows up
+assert_has_feature(
+    16, 10588, 25442, 'pois',
+    { 'kind': 'mast', 'min_zoom': 17 })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -87,6 +87,9 @@ filters:
   - filter: {leisure: stadium}
     min_zoom: LEAST(zoom + 2.30, 15)
     output: {kind: stadium}
+  - filter: {man_made: observatory}
+    min_zoom: 15
+    output: {kind: observatory}
   - filter: {amenity: university}
     min_zoom: LEAST(zoom + 2.55, 15)
     output: {kind: university}
@@ -325,6 +328,18 @@ filters:
   - filter: {man_made: windmill}
     min_zoom: 16
     output: {kind: windmill}
+  - filter: {man_made: communications_tower}
+    min_zoom: 15
+    output: {kind: communications_tower}
+  - filter: {man_made: telescope}
+    min_zoom: GREATEST(15, LEAST(zoom + 0.1, 16))
+    output: {kind: telescope}
+  - filter: {man_made: offshore_platform}
+    min_zoom: 13
+    output: {kind: offshore_platform}
+  - filter: {man_made: water_tower}
+    min_zoom: 15
+    output: {kind: water_tower}
   - filter: {natural: tree}
     min_zoom: 16
     output: {kind: tree}
@@ -355,11 +370,9 @@ filters:
     min_zoom: 17
     output:
       kind: {col: leisure}
-  - filter:
-      man_made: [mast, water_tower]
+  - filter: {man_made: mast}
     min_zoom: 17
-    output:
-      kind: {col: man_made}
+    output: {kind: mast}
   - filter:
       office: [accountant, administrative, advertising_agency, architect, association,
         company, consulting, educational_institution, employment_agency, estate_agent,

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -328,6 +328,9 @@ filters:
   - filter: {natural: tree}
     min_zoom: 16
     output: {kind: tree}
+  - filter: {amenity: ranger_station}
+    min_zoom: 14
+    output: {kind: ranger_station}
   - filter:
       tourism: [camp_site, caravan_site, information, viewpoint]
     min_zoom: 16


### PR DESCRIPTION
Connects with https://github.com/mapzen/vector-datasource/issues/675.

Should be merged after #714 to take advantage of reformatted doc kind listing.

* add man_made outdoor landmarks
* [test] add man_made outdoor landmarks
* [docs] add outdoor man_made landmarks
* [migration] add man_made outdoor landmarks