### PR TITLE
Heights in meters

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -606,3 +606,40 @@ BEGIN
   END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Returns a floating point number in meters for the given unit input text,
+-- which must be of the form of a number (in which case it's assumed it's
+-- meters), or a number followed by a unit (m, ft, '). The distance is
+-- converted into meters and returned, or NULL is returned if the input
+-- could not be understood.
+--
+CREATE OR REPLACE FUNCTION mz_to_float_meters(txt text)
+RETURNS REAL AS $$
+DECLARE
+  decimal_matches text[] :=
+    regexp_matches(txt, '([0-9]+(\.[0-9]*)?) *(mi|km|m|nmi|ft)');
+  imperial_matches text[] :=
+    regexp_matches(txt, E'([0-9]+(\\.[0-9]*)?)\' *(([0-9]+)")?');
+  numeric_matches text[] :=
+    regexp_matches(txt, '([0-9]+(\.[0-9]*)?)');
+BEGIN
+  RETURN CASE
+    WHEN decimal_matches IS NOT NULL THEN
+      CASE
+        WHEN decimal_matches[3] = 'mi'  THEN 1609.3440 * decimal_matches[1]::real
+        WHEN decimal_matches[3] = 'km'  THEN 1000.0000 * decimal_matches[1]::real
+        WHEN decimal_matches[3] = 'm'   THEN    1.0000 * decimal_matches[1]::real
+        WHEN decimal_matches[3] = 'nmi' THEN 1852.0000 * decimal_matches[1]::real
+        WHEN decimal_matches[3] = 'ft'  THEN    0.3048 * decimal_matches[1]::real
+      END
+    WHEN imperial_matches IS NOT NULL THEN
+      CASE WHEN imperial_matches[4] IS NULL THEN
+        0.0254 * (imperial_matches[1]::real * 12)
+      ELSE
+        0.0254 * (imperial_matches[1]::real * 12 + imperial_matches[4]::real)
+      END
+    WHEN numeric_matches IS NOT NULL THEN
+      numeric_matches[1]::real
+    END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/queries.yaml
+++ b/queries.yaml
@@ -123,6 +123,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.remove_zero_area
       - TileStache.Goodies.VecTiles.transform.pois_kind_aeroway_gate
       - TileStache.Goodies.VecTiles.transform.make_representative_point
+      - TileStache.Goodies.VecTiles.transform.height_to_meters
     sort: TileStache.Goodies.VecTiles.sort.pois
   boundaries:
     template: boundaries.jinja2

--- a/test/677-waterfall.py
+++ b/test/677-waterfall.py
@@ -2,7 +2,7 @@
 # Upper Yosemite Falls, because it's so tall at 550 meters, more than 300 meters
 assert_has_feature(
     12, 687, 1583, 'pois',
-    { 'kind': 'waterfall', 'min_zoom': 12 })
+    { 'kind': 'waterfall', 'min_zoom': 12, 'height': 550 })
 
 #https://www.openstreetmap.org/node/2384221575
 # Middle Yosemite Falls, 206 meters, more than 50 meters
@@ -53,3 +53,21 @@ assert_has_feature(
 assert_has_feature(
     14, 2748, 6344, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 14 })
+
+# https://www.openstreetmap.org/node/877270365
+# Rainbow Falls - height 150ft = 45m
+assert_has_feature(
+    14, 4416, 6484, 'pois',
+    { 'kind': 'waterfall', 'min_zoom': 14, 'height': 45.72 })
+
+# https://www.openstreetmap.org/node/404574988
+# Toccoa Falls - height 186' = 56.6929m
+assert_has_feature(
+    13, 2199, 3256, 'pois',
+    { 'kind': 'waterfall', 'min_zoom': 13, 'height': 56.6928 })
+
+# https://www.openstreetmap.org/node/3647404249
+# Eternal Flame Falls - height 9m (with unit)
+assert_has_feature(
+    15, 9215, 12077, 'pois',
+    { 'kind': 'waterfall', 'min_zoom': 15, 'height': 9 })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -179,10 +179,10 @@ filters:
       any:
         - {waterway: waterfall}
         - {natural: waterfall}
-    min_zoom: CASE WHEN to_number("height", '9999.99') < 10 THEN 15
-      WHEN to_number("height", '9999.99') < 50 THEN 14
-      WHEN to_number("height", '9999.99') < 300 THEN 13
-      WHEN to_number("height", '9999.99') >= 300 THEN 12
+    min_zoom: CASE WHEN mz_to_float_meters("height") < 10 THEN 15
+      WHEN mz_to_float_meters("height") < 50 THEN 14
+      WHEN mz_to_float_meters("height") < 300 THEN 13
+      WHEN mz_to_float_meters("height") >= 300 THEN 12
       ELSE GREATEST(LEAST((zoom+1.066)::smallint,
       14), 12) END
     extra_columns: [height]


### PR DESCRIPTION
Added a function in SQL to convert heights to meters, and use this in the test for waterfall zoom level.

Requires mapzen/TileStache#145 for a second conversion of the `height` property into meters for output in tiles.

Added tests for `height`.

Connects to #677.

@nvkelso could you review, please?