### PR TITLE
Fix failing tests

### DIFF
--- a/test/343-winter-sports-resorts.py
+++ b/test/343-winter-sports-resorts.py
@@ -1,4 +1,4 @@
 assert_has_feature(
     15, 5467, 12531, 'landuse',
     { 'kind': 'winter_sports',
-      'sort_key': 33 })
+      'sort_key': 36 })

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -64,13 +64,12 @@ assert_has_feature(
 assert_has_feature(
     15, 9219, 11714, 'pois',
     { 'kind': 'summer_camp', 'min_zoom': 15 })
-    
+
 #https://www.openstreetmap.org/node/4050178586
-# missing
 # Camp Goodtimes
-# assert_has_feature(
-#     15, 5225, 11211, 'pois',
-#     { 'kind': 'summer_camp', 'min_zoom': 15 })    
+assert_has_feature(
+    15, 5225, 11211, 'pois',
+    { 'kind': 'summer_camp', 'min_zoom': 15 })
 
 
 

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -268,10 +268,10 @@ assert_has_feature(
     16, 10551, 22892, 'pois',
     { 'kind': 'swimming_area', 'min_zoom': 16 })
 
-#https://www.openstreetmap.org/node/3738168752
-# Lake Arrowhead
+#https://www.openstreetmap.org/node/3733554139
+# Swimming hole at Seneca Rocks
 assert_has_feature(
-    16, 14857, 26232, 'pois',
+    16, 18319, 25083, 'pois',
     { 'kind': 'swimming_area', 'min_zoom': 16 })
 
 

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -347,15 +347,14 @@ assert_has_feature(
     { 'kind': 'picnic_site', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/400701941
-# missing landuse feature? needs import?
 # Golden Gate Park, SF
-# assert_has_feature(
-#     16, 10474, 25332, 'landuse',
-#     { 'kind': 'picnic_site', 'sort_key': 103 })
+assert_has_feature(
+    16, 10474, 25332, 'landuse',
+    { 'kind': 'picnic_site', 'sort_key': 103 })
 
-# assert_has_feature(
-#     16, 10474, 25332, 'pois',
-#     { 'kind': 'picnic_site', 'min_zoom': 16 })
+assert_has_feature(
+    16, 10474, 25332, 'pois',
+    { 'kind': 'picnic_site', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/231863022
 # building, South Park, SF

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -172,12 +172,11 @@ assert_has_feature(
     { 'kind': 'dam', 'min_zoom': 12 })
 
 #https://www.openstreetmap.org/way/62201624
-# huh, missing in tile, is in DB
 # Named dam line in front of Cherry Lake
 # Should be labeled in the stylesheet, no POI generate
-# assert_has_feature(
-#     12, 683, 1580, 'boundaries',
-#     { 'kind': 'dam', "sort_key": 263 })
+assert_has_feature(
+    12, 683, 1580, 'boundaries',
+    { 'kind': 'dam', "sort_key": 263 })
 
 
 

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -147,11 +147,10 @@ assert_has_feature(
     { 'kind': 'monument', 'min_zoom': 15 })
 
 #https://www.openstreetmap.org/way/66418767
-# huh? this in in the DB, but missing from tiles
 # building, and tourism=attraction, National World War II Memorial
-# assert_has_feature(
-#     15, 9371, 12536, 'pois',
-#     { 'kind': 'monument', 'min_zoom': 15 })
+assert_has_feature(
+    15, 9371, 12536, 'pois',
+    { 'kind': 'monument', 'min_zoom': 15 })
 
 
 

--- a/test/663-combo-outdoor-landuse-pois.py
+++ b/test/663-combo-outdoor-landuse-pois.py
@@ -74,41 +74,37 @@ assert_has_feature(
 
 
 #https://www.openstreetmap.org/node/3838356961
-# huh? it's in the DB but not exporting
 # Battle of Blackburn's Ford (1861)
-# assert_has_feature(
-#     16, 18668, 25092, 'pois',
-#     { 'kind': 'battlefield', 'min_zoom': 17 })
+assert_has_feature(
+    16, 18668, 25092, 'pois',
+    { 'kind': 'battlefield', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/node/3992988013
-# missing, keeping here since we already have one for test, but if the other breaks
 # 2nd Battle of Kernstown
-# assert_has_feature(
-#     16, 18532, 25013, 'pois',
-#     { 'kind': 'battlefield', 'min_zoom': 17 })
+assert_has_feature(
+    16, 18532, 25013, 'pois',
+    { 'kind': 'battlefield', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/231393152
-# huh? it's in the DB but not exporting
 # Antietam National Battlefield
-# assert_has_feature(
-#     10, 290, 389, 'pois',
-#     { 'kind': 'battlefield', 'min_zoom': 10.4417 })
+assert_has_feature(
+    10, 290, 389, 'pois',
+    { 'kind': 'battlefield', 'min_zoom': 10 })
 
-# huh? it's in the DB but not exporting
-# assert_has_feature(
-#     10, 290, 389, 'landuse',
-#     { 'kind': 'battlefield', 'sort_key': 25 })
+assert_has_feature(
+    10, 290, 389, 'landuse',
+    { 'kind': 'battlefield', 'sort_key': 25 })
 
 
 #http://www.openstreetmap.org/way/316054549
 # White Oak Road Battlefield
-# assert_has_feature(
-#     11, 582, 796, 'pois',
-#     { 'kind': 'battlefield', 'min_zoom': 11.0683 })
-# 
-# assert_has_feature(
-#     11, 582, 796, 'landuse',
-#     { 'kind': 'battlefield', 'sort_key': 25 })
+assert_has_feature(
+    11, 582, 796, 'pois',
+    { 'kind': 'battlefield', 'min_zoom': 10.0683 })
+
+assert_has_feature(
+    11, 582, 796, 'landuse',
+    { 'kind': 'battlefield', 'sort_key': 25 })
 
 
 

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -38,7 +38,7 @@ filters:
     output: {kind: city_wall}
     table: osm
   - filter: {waterway: dam}
-    min_zoom: 13
+    min_zoom: 12
     output: {kind: dam}
     table: osm
   - filter: {man_made: snow_fence}

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1,4 +1,7 @@
 filters:
+  - filter: {historic: battlefield}
+    min_zoom: GREATEST(LEAST(zoom, 16), 9)
+    output: {kind: battlefield}
   - filter: {boundary: national_park}
     min_zoom: zoom
     output: {kind: national_park}
@@ -281,9 +284,6 @@ filters:
   - filter: {leisure: water_park}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: water_park}
-  - filter: {historic: battlefield}
-    min_zoom: GREATEST(LEAST(zoom, 16), 9)
-    output: {kind: battlefield}
   - filter: {waterway: dam}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: dam}

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -506,7 +506,7 @@ filters:
     min_zoom: GREATEST(14, LEAST(zoom + 1.32, 15))
     output: {kind: summer_camp }
   - filter: {historic: battlefield}
-    min_zoom: GREATEST(10, LEAST(zoom + 5.0, 17))
+    min_zoom: GREATEST(10, LEAST(zoom + 4.0, 17))
     output: {kind: battlefield }
   - filter: {amenity: boat_storage}
     min_zoom: 17

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -539,5 +539,5 @@ filters:
     min_zoom: GREATEST(14, LEAST(zoom, 15))
     output: {kind: caravan_site }
   - filter: {tourism: picnic_site}
-    min_zoom: GREATEST(15, LEAST(zoom + 1.76, 17))
+    min_zoom: 16
     output: {kind: picnic_site }


### PR DESCRIPTION
I've fixed the YAML where possible, or the tests where not, and they all pass for me now. Other sources of failure might include:

1. Running the migration (or not having run it). Make sure you run `psql -f data/functions.sql $YOUR_DB_NAME` and `python data/migrations/create-sql-functions.py | psql $YOUR_DB_NAME`. And then update the failing feature by running `update planet_osm_XXX set mz_YYY_min_zoom = NULL where ZZZ;` for appropriate values of XXX, YYY and ZZZ. Note that setting the min zoom to `NULL` is actually okay, as the trigger will reset it back to the correct value.
2. Lack of data. I've put together [a little script](https://gist.github.com/zerebubuth/3a3e504ebf1973cdf82eb2f05a696682) which helps import data into your local DB. When I got the latest version of all the failing cases, everything passed.

@nvkelso could you take a look and check the tests are what you wanted, please? Particularly Antietam, which is tagged as a national park as well as a battlefield - to get the tests to pass, I had to move the battlefield first in priority, which I'm not sure is what was intended.

NOTE: The migration already covers this, but a shorter version which just works for this PR is:

```SQL
update planet_osm_point set mz_poi_min_zoom = NULL where tourism='picnic_site';
update planet_osm_polygon set mz_poi_min_zoom = NULL where tourism='picnic_site';
update planet_osm_polygon set mz_landuse_min_zoom = NULL where historic='battlefield';
update planet_osm_point set mz_poi_min_zoom = NULL where historic='battlefield';
update planet_osm_line set mz_boundary_min_zoom = NULL where waterway='dam';
```