### PR TITLE
rescue early path revisions into primary PR

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -556,8 +556,8 @@ RETURNS BOOLEAN AS $$
 BEGIN
     RETURN (
       tags->'type' = 'route' AND
-      tags->'route' IN ('hiking', 'foot') AND
-      tags->'network' IN ('iwn','nwn','rwn','lwn')
+      tags->'route' IN ('hiking', 'foot', 'bicycle') AND
+      tags->'network' IN ('iwn','nwn','rwn','lwn','icn','ncn','rcn','lcn')
     );
 END;
 $$ LANGUAGE plpgsql STABLE;
@@ -572,9 +572,9 @@ BEGIN
   RETURN (
     SELECT
         MIN(
-            CASE WHEN hstore(tags)->'network' IN ('iwn','nwn') THEN 11
-                 WHEN hstore(tags)->'network' IN ('rwn') THEN 12
-                 WHEN hstore(tags)->'network' IN ('lwn') THEN 13
+            CASE WHEN hstore(tags)->'network' IN ('iwn', 'nwn', 'icn','ncn') THEN 11
+                 WHEN hstore(tags)->'network' IN ('rwn', 'rcn') THEN 12
+                 WHEN hstore(tags)->'network' IN ('lwn', 'lcn') THEN 13
             ELSE NULL
             END
         )

--- a/data/migrations/v0.10.0-line.sql
+++ b/data/migrations/v0.10.0-line.sql
@@ -21,7 +21,6 @@ UPDATE planet_osm_line
     mz_calculate_min_zoom_roads(planet_osm_line.*) IS NULL AND
     mz_road_level IS NOT NULL;
 
-
 CREATE INDEX new_planet_osm_line_roads_geom_index ON planet_osm_line USING gist(way) WHERE mz_road_level IS NOT NULL;
 CREATE INDEX new_planet_osm_line_roads_geom_9_index ON planet_osm_line USING gist(way) WHERE mz_road_level <= 9;
 CREATE INDEX new_planet_osm_line_roads_geom_12_index ON planet_osm_line USING gist(way) WHERE mz_road_level <= 12;

--- a/queries.yaml
+++ b/queries.yaml
@@ -376,7 +376,6 @@ post_process:
       end_zoom: 16
       properties: [name, ref, network]
       where: >-
-        (kind == 'path' and zoom < 14) or
         (kind == 'rail' and zoom < 15) or
         (kind == 'minor_road' and zoom < 14) or
         (kind == 'major_road' and zoom <  7) or

--- a/test/593-early-cycleway.py
+++ b/test/593-early-cycleway.py
@@ -1,0 +1,8 @@
+tiles = [
+    [12, 655, 1586]     # way 109993139  cycleway example south of SF, way/109993139, is member of regional cycling network
+]
+
+for z, x, y in tiles:
+    assert_has_feature(
+        z, x, y, 'roads',
+        {'highway': 'cycleway'})

--- a/test/593-early-footway.py
+++ b/test/593-early-footway.py
@@ -13,3 +13,24 @@ for z, x, y in tiles:
     assert_has_feature(
         z, x, y, 'roads',
         {'highway': 'footway'})
+        
+
+#SF State, way/346093021
+assert_no_matching_feature(
+    14, 2617, 6335, 'roads',
+    {'kind': 'path', 'footway': 'sidewalk'})
+
+#SF State, way/346093021
+assert_has_feature(
+    15, 5235, 12671, 'roads',
+    {'kind': 'path', 'footway': 'sidewalk'})
+
+#SF in the Avenues, way/344205837
+assert_no_matching_feature(
+    14, 2617, 6333, 'roads',
+    {'kind': 'path', 'footway': 'sidewalk'})
+
+#SF in the Avenues, way/344205837
+assert_has_feature(
+    15, 5234, 12667, 'roads',
+    {'kind': 'path', 'footway': 'crossing'})

--- a/test/593-early-path.py
+++ b/test/593-early-path.py
@@ -8,4 +8,4 @@ tiles = [
 for z, x, y in tiles:
     assert_has_feature(
         z, x, y, 'roads',
-        {'highway': 'path'})
+        {'highway': 'path', 'name': true})

--- a/test/593-early-step.py
+++ b/test/593-early-step.py
@@ -1,10 +1,20 @@
 tiles = [
     [12,  653, 1582],   # way 24655593   highway=steps, with route regional (Coastal Trail, Marin, II)
-    [13, 1309, 3166],   # way 38060491   highway=steps, no route, but has name, and designation (Levant St Stairway, SF)
-    [13, 1310, 3167]    # way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
+    [13, 1309, 3166]    # way 38060491   highway=steps, no route, but has name, and designation (Levant St Stairway, SF)
 ]
 
 for z, x, y in tiles:
     assert_has_feature(
         z, x, y, 'roads',
         {'highway': 'steps'})
+
+
+# way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
+assert_no_matching_feature(
+    13, 1310, 3167, 'roads',
+    {'kind': 'path', 'footway': 'sidewalk'})
+
+# way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
+assert_has_feature(
+    14, 2620, 6334, 'roads',
+    {'kind': 'path', 'footway': 'sidewalk'})

--- a/test/593-early-track.py
+++ b/test/593-early-track.py
@@ -1,0 +1,8 @@
+tiles = [
+    [12, 654, 1582]     # way/12188550 track example in Marin Headlands, a member of Bay Area Ridge Trail, a regional network
+]
+
+for z, x, y in tiles:
+    assert_has_feature(
+        z, x, y, 'roads',
+        {'highway': 'track'})

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -236,6 +236,7 @@ filters:
       <<: *osm_network_from_tags
       kind: path
       highway: {col: highway}
+      footway: {col: "tags->footway"}
   - filter:
       highway: [steps]
     min_zoom: |

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -201,7 +201,7 @@ filters:
       kind: minor_road
       highway: {col: highway}
   - filter:
-      highway: [pedestrian, track, cycleway]
+      highway: [pedestrian]
     min_zoom: 13
     table: osm
     output:
@@ -210,17 +210,42 @@ filters:
       kind: path
       highway: {col: highway}
   - filter:
-      highway: [path, footway, steps]
+      highway: [path, track, cycleway]
+    min_zoom: |
+      COALESCE(mz_calculate_path_major_route(osm_id), 13)
+    table: osm
+    extra_columns: [bicycle, foot, horse, tracktype, "tags->incline", "tags->trail_visibility", "tags->sac_scale"]
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network_from_tags
+      kind: path
+      highway: {col: highway}
+  - filter:
+      highway: [footway]
     min_zoom: |
       COALESCE(mz_calculate_path_major_route(osm_id),
-        CASE
-          WHEN highway = 'path' THEN 13
-          WHEN mz_is_path_named_or_designated(highway, name, bicycle, foot,
-              horse, tags->'snowmobile', tags->'ski') THEN 13
-          ELSE 14
+        CASE WHEN mz_is_path_named_or_designated(highway, name, bicycle, foot,
+              horse, tags->'snowmobile', tags->'ski')           THEN 13
+             WHEN "tags->footway" IN ('sidewalk', 'crossing')   THEN 15
+        ELSE 14
         END)
     table: osm
-    extra_columns: [bicycle, foot, horse]
+    extra_columns: [bicycle, foot, horse, tracktype, "tags->incline", "tags->trail_visibility", "tags->sac_scale"]
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network_from_tags
+      kind: path
+      highway: {col: highway}
+  - filter:
+      highway: [steps]
+    min_zoom: |
+      COALESCE(mz_calculate_path_major_route(osm_id),
+        CASE WHEN mz_is_path_named_or_designated(highway, name, bicycle, foot,
+              horse, tags->'snowmobile', tags->'ski')           THEN 14
+        ELSE 15
+        END)
+    table: osm
+    extra_columns: [bicycle, foot, horse, tracktype, "tags->incline", "tags->trail_visibility", "tags->sac_scale"]
     output:
       <<: *osm_highway_properties
       <<: *osm_network_from_tags


### PR DESCRIPTION
- [ ] add track & cycleway networks to the mix & update tests
- [ ] stop stripping path names at low zooms (they are like highway names)
- [ ] suppress zoom range of uninteresting footways of type sidewalk or crossing
- [ ] export footway value
- [ ] add extra path properties