### PR TITLE
Add elevation to peaks

### DIFF
--- a/data/migrations/sql.jinja2
+++ b/data/migrations/sql.jinja2
@@ -146,8 +146,12 @@ DECLARE
   row ALIAS FOR $1;
 BEGIN
   RETURN mz_calculate_min_zoom_pois_(
-{%- for param in layers['pois']['params'] %}
+{%- for param in layers['pois']['params'] -%}
+{%- if param.key == '"ele"' %}
+        row.tags->'ele',
+{%- else %}
         row.{{param.key}},
+{%- endif -%}
 {%- endfor %}
         row.tags,
         row.way_area);
@@ -187,7 +191,11 @@ DECLARE
 BEGIN
   RETURN mz_calculate_output_pois_(
 {%- for param in layers['pois']['params'] %}
+{%- if param.key == '"ele"' %}
+        row.tags->'ele',
+{%- else %}
         row.{{param.key}},
+{%- endif -%}
 {%- endfor %}
         row.tags);
 END;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -697,7 +697,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `outreach`
 * `painter`
 * `parking`
-* `peak`
+* `peak` A mountain peak. This may additionally have an `elevation` property giving the elevation in meters, where that information is available.
 * `pet`
 * `petroleum_well`
 * `petting_zoo`
@@ -786,7 +786,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `university`
 * `veterinary`
 * `viewpoint`
-* `volcano`
+* `volcano` The peak of a volcano. This may additionally have an `elevation` property giving the elevation in meters, where that information is available.
 * `walking_guidepost` - Common in Europe for signed walking routes with named junctions. The walking network reference point's `ref` value is derived from one of `iwn_ref`, `nwn_ref`, `rwn_ref` or `lwn_ref`, in descending order and is suitable for naming or use in a shield.
 * `waste_basket`
 * `waste_disposal`

--- a/queries.yaml
+++ b/queries.yaml
@@ -125,6 +125,7 @@ layers:
       - TileStache.Goodies.VecTiles.transform.make_representative_point
       - TileStache.Goodies.VecTiles.transform.height_to_meters
       - TileStache.Goodies.VecTiles.transform.pois_capacity_int
+      - TileStache.Goodies.VecTiles.transform.elevation_to_meters
     sort: TileStache.Goodies.VecTiles.sort.pois
   boundaries:
     template: boundaries.jinja2

--- a/test/523-add-elevation-to-peaks.py
+++ b/test/523-add-elevation-to-peaks.py
@@ -1,0 +1,53 @@
+##
+## A selection of very tall peaks which should be visible at zoom 9.
+##
+
+#http://www.openstreetmap.org/node/358800613
+# Mount Whitney, CA
+assert_has_feature(
+    9, 87, 200, 'pois',
+    { 'kind': 'peak', 'id': 358800613, 'elevation': 4421 })
+
+#http://www.openstreetmap.org/node/358915477
+# Mount Elbert, CO
+assert_has_feature(
+    9, 104, 195, 'pois',
+    { 'kind': 'peak', 'id': 358915477, 'elevation': 4397 })
+
+# http://www.openstreetmap.org/node/1744903493
+# Mount Rainier, WA (volcano)
+assert_has_feature(
+    9, 82, 180, 'pois',
+    { 'kind': 'volcano', 'id': 1744903493, 'elevation': 4392 })
+
+##
+## Some smaller ones which should be visible at a range of zooms
+##
+
+def assert_feature_min_zoom(z, x, y, layer, props):
+    assert_has_feature(z, x, y, layer, props)
+    assert_no_matching_feature(z-1, x/2, y/2, layer, props)
+
+# http://www.openstreetmap.org/node/358792071
+# San Gorgonio Mountain
+assert_feature_min_zoom(
+    10, 179, 408, 'pois',
+    { 'kind': 'peak', 'id': 358792071, 'elevation': 3502 })
+
+#https://www.openstreetmap.org/node/358793535
+# Toro Peak
+assert_feature_min_zoom(
+    11, 361, 821, 'pois',
+    { 'kind': 'peak', 'id': 358793535, 'elevation': 2650 })
+
+#https://www.openstreetmap.org/node/549642731
+# Ventana Double Cone
+assert_feature_min_zoom(
+    12, 663, 1604, 'pois',
+    { 'kind': 'peak', 'id': 549642731, 'elevation': 1477 })
+
+#https://www.openstreetmap.org/node/358796064
+# Chamisal Mountain
+assert_feature_min_zoom(
+    13, 1274, 3100, 'pois',
+    { 'kind': 'peak', 'id': 358796064, 'elevation': 785 })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -13,9 +13,15 @@ filters:
     output: {kind: hospital}
   - filter:
       natural: [peak, volcano]
-    min_zoom: 11
+    min_zoom: CASE WHEN mz_to_float_meters("ele") > 4000 THEN 9
+      WHEN mz_to_float_meters("ele") > 3000 THEN 10
+      WHEN mz_to_float_meters("ele") > 2000 THEN 11
+      WHEN mz_to_float_meters("ele") > 1000 THEN 12
+      ELSE 13
+      END
     output:
       kind: {col: natural}
+      elevation: {col: ele}
   - filter: {railway: station}
     min_zoom: 10
     output: {kind: station}


### PR DESCRIPTION
Connects to #523. Requires mapzen/TileStache#147

Adds an `elevation` property to peaks and volcanoes, which is the height in meters. There's a small amount of fiddling with the polygons table, as `ele` isn't a column there, but is in the points table.

@rmarianski could you review, please?
