### PR TITLE
Add properties to bicycle POIs.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -505,12 +505,17 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `capacity`: Approximate number of total rental bicycles at the bike share station.
 * `network`: The common (sometimes branded) name of the bike share network, eg: "Citi Bike".
 * `operator`: Who actually runs the bike share station, eg: "NYC Bike Share".
+* `ref`: The reference of this rental station, if one is available.
 
 #### POI properties (only on `kind:bicycle_parking`):
 
+* `access`: Whether the bicyle parking is for general public use (`yes`, `permissive`, `public`) or for customers only (`customers`) or private use only (`private`, `no`).
 * `capacity`: Approximate number of total bicycle parking spots.
 * `covered`: Is the parking area covered.
+* `fee`: Whether a fee must be paid to use the bicycle parking (`yes`/`no`).
 * `operator`: Who runs the bike parking lot.
+* `maxstay`: A duration indicating the maximum time a bike is allowed to be parked.
+* `surveillance`: If present, then indicates that there is surveillance (value`yes`), or has a more specific value, e.g: `outdoor`, `public`, `indoor`.
 
 #### POI kind values:
 
@@ -550,7 +555,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `bicycle_rental_station` - Bike share station offering free or low cost bicycle rentals as part of a public bike scheme.
 * `bicycle_repair_station`
 * `bicycle` - Bicycle sales shop, often with bike repair service.
-* `bicycle_guidepost` - Common in Europe for signed bicycle routes with named junctions. The cycle network reference point's `ref` value is derived from one of `icn_ref`, `ncn_ref`, `rcn_ref` or `lcn_ref`, in descending order and is suitable for naming or use in a shield.
+* `bicycle_junction` - Common in Europe for signed bicycle routes with named junctions. The cycle network reference point's `ref` value is derived from one of `icn_ref`, `ncn_ref`, `rcn_ref` or `lcn_ref`, in descending order and is suitable for naming or use in a shield.
 * `biergarten`
 * `block`
 * `boat_rental`
@@ -787,7 +792,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `veterinary`
 * `viewpoint`
 * `volcano`
-* `walking_guidepost` - Common in Europe for signed walking routes with named junctions. The walking network reference point's `ref` value is derived from one of `iwn_ref`, `nwn_ref`, `rwn_ref` or `lwn_ref`, in descending order and is suitable for naming or use in a shield.
+* `walking_junction` - Common in Europe for signed walking routes with named junctions. The walking network reference point's `ref` value is derived from one of `iwn_ref`, `nwn_ref`, `rwn_ref` or `lwn_ref`, in descending order and is suitable for naming or use in a shield.
 * `waste_basket`
 * `waste_disposal`
 * `water_park`

--- a/test/592-add-adjust-bicycle-pois.py
+++ b/test/592-add-adjust-bicycle-pois.py
@@ -14,7 +14,16 @@ assert_has_feature(
 # Citi Bike - Broadway & W 24 St, with network, operator
 assert_has_feature(
     16, 19298, 24633, 'pois',
-    { 'kind': 'bicycle_rental_station', 'min_zoom': 17, 'capacity': 52, 'network': 'Citi Bike' })
+    { 'kind': 'bicycle_rental_station', 'min_zoom': 17,
+      'capacity': 52, 'network': 'Citi Bike', 'operator': 'NYC Bike Share' })
+
+# http://www.openstreetmap.org/node/1960994139
+# Alta Bike Share, Chattanooga, with network, operator, ref, capacity.
+assert_has_feature(
+    16, 17238, 25950, 'pois',
+    { 'kind': 'bicycle_rental_station', 'min_zoom': 17,
+      'capacity': 19, 'network': 'Bike Chattanooga',
+      'operator': 'Alta Bike Share', 'ref': '5' })
 
 # http://www.openstreetmap.org/node/1993249660
 # Cycle barrier in Berkeley
@@ -29,7 +38,8 @@ assert_has_feature(
 # icn_ref=1
 assert_has_feature(
     16, 32382, 22860, 'pois',
-    { 'kind': 'bicycle_guidepost', 'min_zoom': 16, 'ref': '1', 'bicycle_network': 'icn' })
+    { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
+      'bicycle_network': 'icn' })
 
 # No known examples in the world for nodes, and ways don't count
 # ncn_ref=1
@@ -39,21 +49,24 @@ assert_has_feature(
 # rcn_ref=1
 assert_has_feature(
     16, 33322, 21990, 'pois',
-    { 'kind': 'bicycle_guidepost', 'min_zoom': 16, 'ref': '1', 'bicycle_network': 'rcn' })
+    { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
+      'bicycle_network': 'rcn' })
 
 # NOTE: this is strangely in Omaha, NE, USA
 # http://www.openstreetmap.org/node/3269815503
 # lcn_ref=1
 assert_has_feature(
     16, 15299, 24506, 'pois',
-    { 'kind': 'bicycle_guidepost', 'min_zoom': 16, 'ref': '1', 'bicycle_network': 'lcn' })
+    { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
+      'bicycle_network': 'lcn' })
 
 # http://www.openstreetmap.org/node/287609621
 # lcn_ref=2
 #    16, 32570, 21059, 'pois',
 assert_has_feature(
     16, 32570, 21058, 'pois',
-    { 'kind': 'bicycle_guidepost', 'min_zoom': 16, 'ref': '2', 'bicycle_network': 'lcn' })
+    { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '2',
+      'bicycle_network': 'lcn' })
 
 
 # No known examples in the world for nodes, and ways don't count
@@ -67,11 +80,54 @@ assert_has_feature(
 # rwn_ref=1
 assert_has_feature(
     16, 33492, 21929, 'pois',
-    { 'kind': 'walking_guidepost', 'min_zoom': 16, 'ref': '1', 'walking_network': 'rwn' })
+    { 'kind': 'walking_junction', 'min_zoom': 16, 'ref': '1',
+      'walking_network': 'rwn' })
 
 # WARNING: this kind of feature is only available in Europe
 # http://www.openstreetmap.org/node/717593380
 # lwn_ref=1
 assert_has_feature(
     16, 34584, 21219, 'pois',
-    { 'kind': 'walking_guidepost', 'min_zoom': 16, 'ref': 'ST', 'walking_network': 'lwn' })
+    { 'kind': 'walking_junction', 'min_zoom': 16, 'ref': 'ST',
+      'walking_network': 'lwn' })
+
+
+#http://www.openstreetmap.org/node/3161454672
+# bicycle parking with capacity, covered & fee
+assert_has_feature(
+    16, 12378, 26258, 'pois',
+    { 'kind': 'bicycle_parking',
+      'capacity': 10, 'covered': 'yes', 'fee': 'no' })
+
+#http://www.openstreetmap.org/node/1618586234
+# bicycle parking with access, capacity, covered, fee & operator
+assert_has_feature(
+    16, 10413, 22135, 'pois',
+    { 'kind': 'bicycle_parking',
+      'capacity': 100, 'covered': 'yes', 'fee': 'no', 'access': 'customers',
+      'operator': 'Pemberton Gateway Village Suites' })
+
+# WARNING - EXAMPLE IS IN EUROPE
+#http://www.openstreetmap.org/node/1154262723
+# bicycle parking with capacity, covered, fee, maxstay, operator
+assert_has_feature(
+    16, 31627, 21244, 'pois',
+    { 'kind': 'bicycle_parking',
+      'capacity': 200, 'covered': 'yes', 'fee': 'no', 'maxstay': '2 days',
+      'operator': 'Dublin City Council' })
+
+# WARNING - EXAMPLE IS IN EUROPE
+#http://www.openstreetmap.org/node/1116224894
+# bicycle parking with capacity and cyclestreets ID.
+assert_has_feature(
+    16, 32745, 21789, 'pois',
+    { 'kind': 'bicycle_parking',
+      'capacity': 4, 'cyclestreets_id': '27815' })
+
+#http://www.openstreetmap.org/node/2921238315
+# bicycle parking with access, capacity, covered, operator and surveillance
+assert_has_feature(
+    16, 17087, 24822, 'pois',
+    { 'kind': 'bicycle_parking',
+      'access': 'public', 'capacity': 10, 'covered': 'yes',
+      'operator': 'City of Carmel', 'surveillance': 'yes' })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -374,56 +374,56 @@ filters:
       tags->icn_ref: true
     min_zoom: 16
     output:
-      kind: bicycle_guidepost
+      kind: bicycle_junction
       ref: {col: tags->icn_ref}
       bicycle_network: icn
   - filter:
       tags->ncn_ref: true
     min_zoom: 16
     output:
-      kind: bicycle_guidepost
+      kind: bicycle_junction
       ref: {col: tags->ncn_ref}
       bicycle_network: ncn
   - filter:
       tags->rcn_ref: true
     min_zoom: 16
     output:
-      kind: bicycle_guidepost
+      kind: bicycle_junction
       ref: {col: tags->rcn_ref}
       bicycle_network: rcn
   - filter:
       tags->lcn_ref: true
     min_zoom: 16
     output:
-      kind: bicycle_guidepost
+      kind: bicycle_junction
       ref: {col: tags->lcn_ref}
       bicycle_network: lcn
   - filter:
       tags->iwn_ref: true
     min_zoom: 16
     output:
-      kind: walking_guidepost
+      kind: walking_junction
       ref: {col: tags->iwn_ref}
       walking_network: rwn
   - filter:
       tags->nwn_ref: true
     min_zoom: 16
     output:
-      kind: walking_guidepost
+      kind: walking_junction
       ref: {col: tags->nwn_ref}
       walking_network: nwn
   - filter:
       tags->rwn_ref: true
     min_zoom: 16
     output:
-      kind: walking_guidepost
+      kind: walking_junction
       ref: {col: tags->rwn_ref}
       walking_network: rwn
   - filter:
       tags->lwn_ref: true
     min_zoom: 16
     output:
-      kind: walking_guidepost
+      kind: walking_junction
       ref: {col: tags->lwn_ref}
       walking_network: lwn
   - filter:
@@ -490,14 +490,20 @@ filters:
       network:  {col: tags->network}
       operator: {col: operator}
       capacity: {col: tags->capacity}
+      ref: {col: ref}
   - filter:
       amenity: [bicycle_parking]
     min_zoom: 17
     output:
       kind: {col: amenity}
+      access: {col: access}
       operator: {col: operator}
       capacity: {col: tags->capacity}
-      covered: {col: tags->covered}
+      covered: {col: covered}
+      fee: {col: tags->fee}
+      cyclestreets_id: {col: tags->cyclestreets_id}
+      maxstay: {col: tags->maxstay}
+      surveillance: {col: tags->surveillance}
   - filter:
       barrier: [cycle_barrier]
     min_zoom: 18


### PR DESCRIPTION
Include extra properties on bicycle POIs. Rename 'guidepost' to 'junction'.

Connects to #592.

@rmarianski could you review, please?

(Note that the migration is already included in v0.10, but to do migrations relating specifically to this PR, `update planet_osm_point set mz_poi_min_zoom=null where amenity in ('bicycle_rental', 'bicycle_parking') OR shop='bicycle' OR tags ? 'icn_ref' OR tags ? 'ncn_ref' OR tags ? 'rcn_ref' OR tags ? 'lcn_ref';` and similar for `planet_osm_polygon`. Also, a couple of test cases are in Europe - I've been using [this script](https://gist.github.com/zerebubuth/3a3e504ebf1973cdf82eb2f05a696682) to pull them in individually.)