### PR TITLE
Update boundaries docs for normalized kind values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.10.0
+-------
+* remove `type` property from Natural Earth `boundaries` layer features
+
 v0.9.1
 ------
 * **Release date**: 2016-03-28. _Live in prod: 2015-03-30._

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -108,8 +108,6 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 
 ![image](images/mapzen-vector-tile-docs-barriers.png)
 
-**Gotchas:** Boundary `kind` values are not yet normalized between OpenStreetMap and Natural Earth. See Boundary kind values (line) gotchas section below for more detail.
-
 #### Boundary properties (common):
 
 * `name`
@@ -135,32 +133,23 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 
 #### Boundary kind values:
 
-* `1st Order Admin Lines`
-* `Admin-0 country`
-* `Admin-1 boundary`
-* `Admin-1 region boundary`
+* `aboriginal lands`
 * `city_wall`
 * `country`
 * `county`
 * `dam`
-* `Disputed (please verify)`
+* `disputed`
 * `fence`
-* `Indefinite (please verify)`
-* `Indeterminant frontier`
-* `International boundary (verify)`
-* `Lease limit`
-* `Line of control (please verify)`
+* `indefinite`
+* `indeterminate`
+* `lease_limit`
+* `line_of_control`
+* `macroregion`
 * `municipality`
-* `Overlay limit`
+* `overlay_limit`
 * `retaining_wall`
 * `snow_fence`
 * `state`
-
-**Gotchas:**
-
-* `Admin-0 country` and `country` are equivalent, **both** should be used in filters.
-* `Admin-1 boundary` and `state` are equivalent, **both** should be used in filters.
-* Don't rely on `Admin-1 statistical boundary`, `Admin-1 statistical meta bounds`, those will probably be removed in future tile versions.
 
 #### Boundary type values:
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -87,7 +87,7 @@ draw:
 
 ### Layer reference
 
-Mapzen vector tiles include 9 layers:   
+Mapzen vector tiles include 9 layers:
 
 * `boundaries`, `buildings`, `earth`, `landuse`, `places`, `pois`, `roads`, `transit`, and `water`
 
@@ -123,7 +123,6 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 * `name:left`: See name section above, other variants like `old_name` also supported.
 * `name:right`: See name section above, other variants like `old_name` also supported.
 * `maritime_boundary`: a special Mapzen calculated value loosely coupled with OpenStreetMap's maritime tag, but with spatial buffer processing for lines falling in the ocean.
-* `type`: required at zooms less than 8 coming from Natural Earth for country and state (zoom 2+) boundaries, roughly equivalent to OSM's `admin_level` values.
 
 #### Boundary properties (optional):
 
@@ -150,17 +149,6 @@ Combination of OpenStreetMap administrative boundaries (zoom >= 8), Natural Eart
 * `retaining_wall`
 * `snow_fence`
 * `state`
-
-#### Boundary type values:
-
-* `Country`
-* `Dependency`
-* `Disputed`
-* `Indeterminate`
-* `Lease`
-* `Sovereign country`
-* `Metropolitan county`
-* `Modern administrative boundary`
 
 ## Buildings and Addresses
 

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -1,15 +1,14 @@
-{% macro ne_boundary_cols(type) %}
+{% macro ne_boundary_cols() %}
     gid AS __id__,
     {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
     scalerank::float,
-    mz_calculate_output_boundaries(t.*) AS mz_properties,
-    '{{ type }}' AS type
+    mz_calculate_output_boundaries(t.*) AS mz_properties
 {% endmacro %}
 
 {% if zoom < 2 %}
 
 SELECT
-    {{ ne_boundary_cols('country') }}
+    {{ ne_boundary_cols() }}
 FROM
     ne_110m_admin_0_boundary_lines_land t
 WHERE
@@ -19,7 +18,7 @@ WHERE
 {% elif 2 <= zoom < 5 %}
 
 SELECT
-    {{ ne_boundary_cols('country') }}
+    {{ ne_boundary_cols() }}
 FROM
     ne_50m_admin_0_boundary_lines_land t
 WHERE
@@ -29,7 +28,7 @@ WHERE
 UNION ALL
 
 SELECT
-    {{ ne_boundary_cols('state') }}
+    {{ ne_boundary_cols() }}
 FROM
     ne_50m_admin_1_states_provinces_lines t
 WHERE
@@ -41,7 +40,7 @@ WHERE
 SELECT
     name,
     labelrank,
-    {{ ne_boundary_cols('country') }}
+    {{ ne_boundary_cols() }}
 FROM
     ne_10m_admin_0_boundary_lines_land t
 WHERE
@@ -53,7 +52,7 @@ UNION ALL
 SELECT
     name,
     NULL AS labelrank,
-    {{ ne_boundary_cols('state') }}
+    {{ ne_boundary_cols() }}
 FROM
     ne_10m_admin_1_states_provinces_lines t
 WHERE


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/718

The `type` values that are coming back from the `ne` queries are now _always_ either `country` or `state`. Since the `kind`s have been normalized, should we just drop the `type` property completely? The docs currently don't reflect what's going on, and I'm happy to update them subsequently to what we want to do.

@nvkelso, @zerebubuth could you review please?