### PR TITLE
Tile kind rank for peaks

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -526,6 +526,11 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `maxstay`: A duration indicating the maximum time a bike is allowed to be parked.
 * `surveillance`: If present, then indicates that there is surveillance (value`yes`), or has a more specific value, e.g: `outdoor`, `public`, `indoor`.
 
+#### POI properties (only on `kind:peak` and `kind:volcano`):
+
+* `elevation`: Elevation of the peak or volcano in meters, where available.
+* `kind_tile_rank`: A rank of each peak or volcano, with 1 being the most important. Both peaks and volcanos are scored in the same scale. When the zoom is less than 16, only five of these features are included in each tile. At zoom 16, all the features are - although it's rare to have more than 5 peaks in a zoom 16 tile.
+
 #### POI kind values:
 
 * `accountant`
@@ -711,7 +716,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `outreach`
 * `painter`
 * `parking`
-* `peak` A mountain peak. This may additionally have an `elevation` property giving the elevation in meters, where that information is available.
+* `peak` A mountain peak. See above for properties available on peaks and volcanos.
 * `pet`
 * `petroleum_well`
 * `petting_zoo`
@@ -800,7 +805,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `university`
 * `veterinary`
 * `viewpoint`
-* `volcano` The peak of a volcano. This may additionally have an `elevation` property giving the elevation in meters, where that information is available.
+* `volcano` The peak of a volcano. See above for properties available on peaks and volcanos.
 * `walking_junction` - Common in Europe for signed walking routes with named junctions. The walking network reference point's `ref` value is derived from one of `iwn_ref`, `nwn_ref`, `rwn_ref` or `lwn_ref`, in descending order and is suitable for naming or use in a shield.
 * `waste_basket`
 * `waste_disposal`

--- a/queries.yaml
+++ b/queries.yaml
@@ -357,7 +357,7 @@ post_process:
     params:
       source_layer: pois
       items_matching:
-        kind: peak
+        kind: [peak, volcano]
       rank_key: kind_tile_rank
       start_zoom: 9
   - fn: TileStache.Goodies.VecTiles.transform.drop_properties
@@ -467,5 +467,5 @@ post_process:
       source_layer: pois
       start_zoom: 9
       end_zoom: 15
-      items_matching: { kind: peak }
+      items_matching: { kind: [peak, volcano] }
       max_items: 5

--- a/queries.yaml
+++ b/queries.yaml
@@ -353,6 +353,13 @@ post_process:
         kind: [neighbourhood, microhood, macrohood]
       rank_key: kind_tile_rank
       start_zoom: 11
+  - fn: TileStache.Goodies.VecTiles.transform.rank_features
+    params:
+      source_layer: pois
+      items_matching:
+        kind: peak
+      rank_key: kind_tile_rank
+      start_zoom: 9
   - fn: TileStache.Goodies.VecTiles.transform.drop_properties
     params:
       source_layer: places
@@ -455,3 +462,10 @@ post_process:
       end_zoom: 13
       items_matching: { kind: station }
       max_items: 30
+  - fn: TileStache.Goodies.VecTiles.transform.keep_n_features
+    params:
+      source_layer: pois
+      start_zoom: 9
+      end_zoom: 15
+      items_matching: { kind: peak }
+      max_items: 5

--- a/test/524-peak-kind-tile-rank.py
+++ b/test/524-peak-kind-tile-rank.py
@@ -1,0 +1,78 @@
+# the tile 11/420/779 contains all the peaks below. so many, it seems, that
+# they ran out of names!
+#
+# not all of these should appear in the output tile - and they should be ranked
+# according to the elevation descending.
+#
+# elev,                    url,                       name
+# 2991, https://www.openstreetmap.org/node/358914475, Shock Hill
+# 3019, https://www.openstreetmap.org/node/358914488, Barney Ford Hill
+# 3062, https://www.openstreetmap.org/node/358914492, Little Mountain
+# 3187, https://www.openstreetmap.org/node/358914480, Gibson Hill
+# 3259, https://www.openstreetmap.org/node/358914483, Prospect Hill
+# 3479, https://www.openstreetmap.org/node/358914525, Mount Argentine
+# 3638, https://www.openstreetmap.org/node/358914415, Gold Hill
+# 3763, https://www.openstreetmap.org/node/358914356, Mayflower Hill
+# 3835, https://www.openstreetmap.org/node/358914437, Tenmile Range Peak 6
+# 3857, https://www.openstreetmap.org/node/358914444, Tenmile Range Peak 7
+# 3943, https://www.openstreetmap.org/node/358914424, Little Bartlett Mountain
+# 3955, https://www.openstreetmap.org/node/324759328, Peak 8
+# 3992, https://www.openstreetmap.org/node/358914502, Peak 9
+# 4016, https://www.openstreetmap.org/node/358914514, Mount Helen
+# 4020, https://www.openstreetmap.org/node/358914547, Red Peak
+# 4030, https://www.openstreetmap.org/node/358914543, Red Mountain
+# 4086, https://www.openstreetmap.org/node/358914539, North Star Mountain
+# 4128, https://www.openstreetmap.org/node/358914432, Bartlett Mountain
+# 4144, https://www.openstreetmap.org/node/358931368, Father Dyer Peak
+# 4150, https://www.openstreetmap.org/node/358914505, Tenmile Range Peak 10
+# 4154, https://www.openstreetmap.org/node/358914428, Wheeler Mountain
+# 4210, https://www.openstreetmap.org/node/358914674, Clinton Peak
+# 4211, https://www.openstreetmap.org/node/358946509, Atlantic Peak
+# 4213, https://www.openstreetmap.org/node/358914509, Crystal Peak
+# 4227, https://www.openstreetmap.org/node/358914519, Pacific Peak
+# 4239, https://www.openstreetmap.org/node/358914419, Fletcher Mountain
+# 4348, https://www.openstreetmap.org/node/358914530, Quandary Peak
+
+def count_matching(features, props):
+    num_matches = 0
+
+    for f in features:
+        f_props = f['properties']
+        match = True
+
+        for k, v in props.iteritems():
+            got_v = f_props.get(k)
+            if got_v != v:
+                match = False
+
+        if match:
+            num_matches += 1
+
+    return num_matches
+
+
+with features_in_tile_layer(11, 420, 779, 'pois') as features:
+    def assert_peak(rank, elevation, name):
+        properties = {'kind': 'peak', 'elevation': elevation, 'name': name,
+                      'kind_tile_rank': rank}
+        num_matching = count_matching(features, properties)
+        if num_matching != 1:
+            raise Exception, "Did not find peak matching properties %r." \
+                % properties
+
+    assert_peak(1, 4348, 'Quandary Peak')
+    assert_peak(2, 4239, 'Fletcher Mountain')
+    assert_peak(3, 4227, 'Pacific Peak')
+    assert_peak(4, 4213, 'Crystal Peak')
+    assert_peak(5, 4211, 'Atlantic Peak')
+
+    num_matching = count_matching(features, {'kind': 'peak'})
+    if num_matching > 5:
+        raise Exception, "Found %d peaks, but should only have five." \
+            % num_matching
+
+# this tile has 7 peaks in it, and at z16 we should keep all of them
+with features_in_tile_layer(16, 12372, 26269, 'pois') as features:
+    num = count_matching(features, {'kind': 'peak'})
+    if num != 7:
+        raise Exception, "Found %d peaks, but expected seven." % num

--- a/test/524-peak-kind-tile-rank.py
+++ b/test/524-peak-kind-tile-rank.py
@@ -76,3 +76,17 @@ with features_in_tile_layer(16, 12372, 26269, 'pois') as features:
     num = count_matching(features, {'kind': 'peak'})
     if num != 7:
         raise Exception, "Found %d peaks, but expected seven." % num
+
+# check that volcanos are sorted along with other kinds of peak
+with features_in_tile_layer(12, 662, 1443, 'pois') as features:
+    def assert_peak(rank, elevation, kind, name):
+        properties = {'kind': kind, 'elevation': elevation, 'name': name,
+                      'kind_tile_rank': rank}
+        num_matching = count_matching(features, properties)
+        if num_matching != 1:
+            raise Exception, "Did not find %s matching properties %r." \
+                % (kind, properties)
+
+    assert_peak(1, 4392, 'volcano', 'Mount Rainier')
+    assert_peak(2, 4302, 'peak',    'Point Success')
+    assert_peak(3, 3863, 'peak',    'Gibraltar Rock')


### PR DESCRIPTION
Adds a `kind_tile_rank` for peaks and volcanos, and limits the number at zoom < 16 to 5 per tile.

Connects to #524. Requires mapzen/TileStache#148.

@rmarianski could you review, please?
