### PR TITLE
Check we don't get mz_is_building.

### DIFF
--- a/test/731-return-of-the-zombie-buildings.py
+++ b/test/731-return-of-the-zombie-buildings.py
@@ -1,0 +1,5 @@
+# mz_is_building is an internal tag and shouldn't be present on any output
+# feature.
+assert_no_matching_feature(
+    12, 653, 1582, 'buildings',
+    { 'mz_is_building': None })


### PR DESCRIPTION
Add a test that we don't get `mz_is_building` on any output building in the example test tile.

I can't reproduce the problem locally, and I don't see it in dev for that tile. But it seems that we should have this test to make sure we don't regress on this again.

Connects to #731.

@rmarianski could you review, please?
