### PR TITLE
Update sort key tunnel test because data changed.

### DIFF
--- a/test/546-road-sort-keys-tunnel.py
+++ b/test/546-road-sort-keys-tunnel.py
@@ -4,10 +4,12 @@ assert_has_feature(
     {"kind": "highway", "highway": "motorway", "id": 167952621,
      "name": "Presidio Pkwy.", "is_tunnel": "yes", "sort_key": 331})
 
+# http://www.openstreetmap.org/way/89912879
+# http://www.openstreetmap.org/way/89911760
 assert_has_feature(
-    18, 45540, 87380, "roads",
-    {"kind": "major_road", "highway": "trunk", "id": 268517418,
-     "name": "Trans-Canada Hwy.", "is_tunnel": "yes", "sort_key": 329})
+    16, 19829, 24234, "roads",
+    {"kind": "major_road", "highway": "trunk", "id": set([89912879, 89911760]),
+     "name": "Sullivan Square Underpass", "is_tunnel": "yes", "sort_key": 329})
 
 assert_has_feature(
     18, 67234, 97737, "roads",


### PR DESCRIPTION
[TCH](http://www.openstreetmap.org/way/268517418) was updated to layer=-1, which changed the sort key. Updating test to point at [another layer=null trunk tunnel](http://www.openstreetmap.org/way/89912879#map=16/42.3811/-71.0690).

The `set()` of IDs is in there because we seem to be merging roads - are we intending to do that at z16?

@rmarianski could you review, please?