### PR TITLE
Include highway=footway|pedestrian for polys only

### DIFF
--- a/data/migrations/create-sql-functions.py
+++ b/data/migrations/create-sql-functions.py
@@ -192,6 +192,23 @@ class NotRule(object):
         return self.rule.columns()
 
 
+class ExpressionRule(object):
+
+    def __init__(self, column, expr, extra_columns=None):
+        self.column = column
+        self.expr = expr
+        self.extra_columns = extra_columns
+
+    def as_sql(self):
+        return self.expr
+
+    def columns(self):
+        cols = [self.column]
+        if self.extra_columns:
+            cols.extend(self.extra_columns)
+        return cols
+
+
 def create_level_filter_rule(filter_level, combinator=AndRule):
     rules = []
     if not isinstance(filter_level, list):
@@ -232,6 +249,9 @@ def create_filter_rule(filter_key, filter_value):
                 rule = NotEqualsRule(filter_key, filter_value[1:])
             elif isinstance(filter_value, dict) and 'min' in filter_value:
                 rule = GreaterOrEqualsRule(filter_key, filter_value['min'])
+            elif isinstance(filter_value, dict) and 'expr' in filter_value:
+                rule = ExpressionRule(
+                    filter_key, filter_value['expr'], filter_value.get('cols'))
             else:
                 rule = EqualsRule(filter_key, filter_value)
     return rule

--- a/data/migrations/sql.jinja2
+++ b/data/migrations/sql.jinja2
@@ -85,7 +85,8 @@ CREATE OR REPLACE FUNCTION mz_calculate_output_landuse_(
 {%- for param in layers['landuse']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        tags hstore)
+        tags hstore,
+        way_area real)
 RETURNS HSTORE AS $$
 BEGIN
   RETURN {{ layers['landuse']['kind_case_statement'] }};
@@ -102,7 +103,8 @@ BEGIN
 {%- for param in layers['landuse']['params'] %}
         row.{{param.key}},
 {%- endfor %}
-        row.tags);
+        row.tags,
+        0::real);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
@@ -116,7 +118,8 @@ BEGIN
 {%- for param in layers['landuse']['params'] %}
         row.{{param.key}},
 {%- endfor %}
-        row.tags);
+        row.tags,
+        row.way_area);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
@@ -130,7 +133,8 @@ BEGIN
 {%- for param in layers['landuse']['params'] %}
         row.{{param.key}},
 {%- endfor %}
-        row.tags);
+        row.tags,
+        0::real);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/test/776-duplicate-footway.py
+++ b/test/776-duplicate-footway.py
@@ -1,0 +1,15 @@
+#  Way: 128534087 http://www.openstreetmap.org/way/128534087
+assert_has_feature(
+    16, 10482, 25330, 'roads',
+    { 'id': 128534087 })
+assert_no_matching_feature(
+    16, 10482, 25330, 'landuse',
+    { 'id': 128534087 })
+
+# Way: 367756094 http://www.openstreetmap.org/way/367756094
+assert_has_feature(
+    16, 10465, 25331, 'roads',
+    { 'id': 367756094 })
+assert_no_matching_feature(
+    16, 10465, 25331, 'landuse',
+    { 'id': 367756094 })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -119,10 +119,14 @@ filters:
   - filter: {natural: beach}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: beach}
-  - filter: {highway: pedestrian}
+  - filter:
+      highway: pedestrian
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: pedestrian}
-  - filter: {highway: footway}
+  - filter:
+      highway: footway
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: footway}
   - filter: {amenity: university}

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -162,16 +162,24 @@ filters:
   - filter: {amenity: prison}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: prison}
-  - filter: {aeroway: runway}
+  - filter:
+      aeroway: runway
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: runway}
-  - filter: {aeroway: taxiway}
+  - filter:
+      aeroway: taxiway
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: taxiway}
-  - filter: {aeroway: apron}
+  - filter:
+      aeroway: apron
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: apron}
-  - filter: {aeroway: aerodrome}
+  - filter:
+      aeroway: aerodrome
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: aerodrome}
   - filter: {tags->zoo: enclosure}
@@ -237,34 +245,54 @@ filters:
   - filter: {tourism: winery}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: winery}
-  - filter: {man_made: pier}
+  - filter:
+      man_made: pier
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: pier}
-  - filter: {man_made: wastewater_plant}
+  - filter:
+      man_made: wastewater_plant
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: wastewater_plant}
-  - filter: {man_made: works}
+  - filter:
+      man_made: works
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: works}
-  - filter: {man_made: bridge}
+  - filter:
+      man_made: bridge
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: bridge}
-  - filter: {man_made: tower}
+  - filter:
+      man_made: tower
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: tower}
-  - filter: {man_made: breakwater}
+  - filter:
+      man_made: breakwater
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: breakwater}
-  - filter: {man_made: water_works}
+  - filter:
+      man_made: water_works
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: water_works}
-  - filter: {man_made: groyne}
+  - filter:
+      man_made: groyne
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: groyne}
-  - filter: {man_made: dike}
+  - filter:
+      man_made: dike
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: dike}
-  - filter: {man_made: cutline}
+  - filter:
+      man_made: cutline
+      way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: cutline}
   - filter: {power: plant}

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -172,14 +172,10 @@ filters:
       way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: taxiway}
-  - filter:
-      aeroway: apron
-      way_area: {expr: "way_area > 0"}
+  - filter: {aeroway: apron}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: apron}
-  - filter:
-      aeroway: aerodrome
-      way_area: {expr: "way_area > 0"}
+  - filter: {aeroway: aerodrome}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: aerodrome}
   - filter: {tags->zoo: enclosure}
@@ -250,24 +246,16 @@ filters:
       way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: pier}
-  - filter:
-      man_made: wastewater_plant
-      way_area: {expr: "way_area > 0"}
+  - filter: {man_made: wastewater_plant}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: wastewater_plant}
-  - filter:
-      man_made: works
-      way_area: {expr: "way_area > 0"}
+  - filter: {man_made: works}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: works}
-  - filter:
-      man_made: bridge
-      way_area: {expr: "way_area > 0"}
+  - filter: {man_made: bridge}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: bridge}
-  - filter:
-      man_made: tower
-      way_area: {expr: "way_area > 0"}
+  - filter: {man_made: tower}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: tower}
   - filter:
@@ -275,9 +263,7 @@ filters:
       way_area: {expr: "way_area > 0"}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: breakwater}
-  - filter:
-      man_made: water_works
-      way_area: {expr: "way_area > 0"}
+  - filter: {man_made: water_works}
     min_zoom: GREATEST(LEAST(zoom, 16), 9)
     output: {kind: water_works}
   - filter:


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/776

@nvkelso could you review please?

Migration required is:
```sql
UPDATE planet_osm_line
  SET mz_landuse_min_zoom = mz_calculate_min_zoom_landuse(planet_osm_line.*)
  WHERE
    highway IN ('pedestrian', 'footway');
```
