### PR TITLE
Fix island label placements.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -298,12 +298,14 @@ post_process:
       source_layer: earth
       label_property_name: label_placement
       label_property_value: "yes"
+      geom_types: [Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]
   - fn: TileStache.Goodies.VecTiles.transform.drop_features_where
     params:
       source_layer: earth
-      start_zoom: 9
+      start_zoom: 0
       where: >-
-        'label_placement' not in properties and kind in ('archipelago', 'island', 'islet')
+        'label_placement' not in properties and kind in
+        ('archipelago', 'island', 'islet', 'continent', 'valley', 'ridge')
   - fn: TileStache.Goodies.VecTiles.transform.generate_address_points
     params:
       source_layer: buildings

--- a/test/399-add-island-labels.py
+++ b/test/399-add-island-labels.py
@@ -187,3 +187,50 @@ assert_has_feature(
 assert_has_feature(
     16, 10465, 25326, 'earth',
     { 'kind': 'islet', 'label_placement': 'yes', 'name': 'Little Mile Rock', 'min_zoom': 17 })
+
+# LARGE island labels (from place polygons)
+# http://www.openstreetmap.org/relation/4227580
+# Manitoulin Island, Canada
+assert_has_feature(
+    7, 34, 45, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Manitoulin Island' })
+
+# LARGE island labels (from place polygons)
+# http://www.openstreetmap.org/relation/5176042
+# Trinidad, the island of the nation
+assert_has_feature(
+    7, 42, 60, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Trinidad' })
+
+# island polygon split across multiple tiles shouldn't get a label placement
+# in each tile, only one.
+# http://www.openstreetmap.org/way/26767313
+# Treasure Island, San Francisco
+assert_has_feature(
+    14, 2622, 6329, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Treasure Island' })
+# neighbouring tiles should not have a placement
+assert_no_matching_feature(
+    14, 2623, 6329, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Treasure Island' })
+assert_no_matching_feature(
+    14, 2622, 6340, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Treasure Island' })
+assert_no_matching_feature(
+    14, 2623, 6340, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Treasure Island' })
+
+# multi-polygonal islands
+# http://www.openstreetmap.org/relation/5344925
+# Islas Marietas
+# main island should get label
+assert_has_feature(
+    15, 6773, 14457, 'earth',
+    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Islas Marietas' })
+# FUTURE: smaller island parts should not
+#assert_no_matching_feature(
+#    15, 6774, 14457, 'earth',
+#    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Islas Marietas' })
+#assert_no_matching_feature(
+#    15, 6775, 14457, 'earth',
+#    { 'kind': 'island', 'label_placement': 'yes', 'name': 'Islas Marietas' })

--- a/yaml/earth.yaml
+++ b/yaml/earth.yaml
@@ -5,7 +5,6 @@ filters:
     min_zoom: 0
     output:
       kind: continent
-      label_placement: 'yes'
     table: osm
   - filter:
       place: archipelago
@@ -16,7 +15,6 @@ filters:
     min_zoom: 15
     output:
       kind: archipelago
-      label_placement: 'yes'
     table: osm
   - filter:
       place: island
@@ -24,7 +22,6 @@ filters:
     min_zoom: GREATEST(7, LEAST((zoom+5.75)::smallint, 15))
     output:
       kind: island
-      label_placement: 'yes'
     table: osm
   - filter:
       place: islet
@@ -32,7 +29,6 @@ filters:
     min_zoom: GREATEST(15, LEAST((zoom+3.5)::smallint, 17))
     output:
       kind: islet
-      label_placement: 'yes'
     table: osm
   - filter: {natural: cliff}
     min_zoom: 13
@@ -48,7 +44,6 @@ filters:
     min_zoom: 13
     output:
       kind: ridge
-      label_placement: 'yes'
     table: osm
   - filter:
       natural: valley
@@ -56,7 +51,6 @@ filters:
     min_zoom: 13
     output:
       kind: valley
-      label_placement: 'yes'
     table: osm
   - filter: {gid: true}
     min_zoom: 0


### PR DESCRIPTION
Don't allow polygons with `label_placement:yes` set in output, as Tangram will label these. Instead, generate the label points using the post-processor and delete the original geometry.

For future work: We should probably only be labelling the largest island in a multipolygon with the island label, or at least suppressing the nearby ones until later zooms.

Also: should we have a filter in the output which disallows setting `label_placement:yes` directly from the YAML? Given that the YAML-generated functions can be applied to points, lines and polygons?

Connects to #399. Requires mapzen/TileStache#153.

@rmarianski could you review, please?