### PR TITLE
Update state boundaries from NE to include statistical boundaries.

### DIFF
--- a/test/797-add-missing-boundaries.py
+++ b/test/797-add-missing-boundaries.py
@@ -1,0 +1,10 @@
+# NE data - no OSM elements
+# boundary between NV and CA is _also_ a "statistical" boundary
+assert_has_feature(
+    7, 21, 49, 'boundaries',
+    { 'kind': 'state' })
+
+# boundary between MT and ND is _also_ a "statistical meta" boundary
+assert_has_feature(
+    7, 21, 49, 'boundaries',
+    { 'kind': 'state' })

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -57,7 +57,11 @@ filters:
     min_zoom: 0
     output: {kind: state, admin_level: '4'}
     table: ne
-  - filter: {featurecla: Admin-1 boundary}
+  - filter:
+      featurecla:
+        - Admin-1 boundary
+        - Admin-1 statistical boundary
+        - Admin-1 statistical meta bounds
     min_zoom: 0
     output: {kind: state, admin_level: '4'}
     table: ne
@@ -92,14 +96,4 @@ filters:
   - filter: {featurecla: Overlay limit}
     min_zoom: 0
     output: {kind: overlay_limit}
-    table: ne
-  - filter: {featurecla: Admin-1 statistical boundary}
-    min_zoom: null
-    output:
-      kind: {expr: null}
-    table: ne
-  - filter: {featurecla: Admin-1 statistical meta bounds}
-    min_zoom: null
-    output:
-      kind: {expr: null}
     table: ne


### PR DESCRIPTION
Include `Admin-1 statistical boundary` and `Admin-1 statistical meta bounds` as types of `state` boundary.

Connects to #797.

This was (somewhat surprisingly) the only migration I needed to run to get the tests to pass. Since this is on top of the v0.10.0 tag, will we tag the pre-merge state as v0.10.1? If so, then it should already be covered by the existing migrations in the repo, but the shorter version is:

```SQL
update ne_10m_admin_1_states_provinces_lines
set mz_boundary_min_zoom = mz_calculate_min_zoom_boundaries(ne_10m_admin_1_states_provinces_lines.*)
where featurecla in ('Admin-1 statistical boundary', 'Admin-1 statistical meta bounds');
```

@rmarianski could you review, please?