### PR TITLE
Test more than one thing

### DIFF
--- a/test/797-add-missing-boundaries.py
+++ b/test/797-add-missing-boundaries.py
@@ -6,5 +6,5 @@ assert_has_feature(
 
 # boundary between MT and ND is _also_ a "statistical meta" boundary
 assert_has_feature(
-    7, 21, 49, 'boundaries',
+    7, 27, 44, 'boundaries',
     { 'kind': 'state' })


### PR DESCRIPTION
The test _should_ have tested two boundaries with different `featurecla`, but ended up being a copy/paste error. This fixes that.

Connects to #797.

@rmarianski could you review, please?