### PR TITLE
Add corridors, crossing, sidewalk

### DIFF
--- a/test/605-corridor.py
+++ b/test/605-corridor.py
@@ -1,0 +1,5 @@
+# Way: The Nave (205644309)
+# http://www.openstreetmap.org/way/205644309
+assert_has_feature(
+    16, 10485, 25332, 'roads',
+    { 'id': 205644309, 'kind': 'path', 'highway': 'corridor' })

--- a/test/605-crosswalk-sidewalk.py
+++ b/test/605-crosswalk-sidewalk.py
@@ -1,0 +1,10 @@
+# http://www.openstreetmap.org/way/367770916
+assert_has_feature(
+    16, 10478, 25323, 'roads',
+    { 'id': 367770916, 'kind': 'path', 'crossing': 'zebra' })
+
+# Way: The Embarcadero (397140734)
+# http://www.openstreetmap.org/way/397140734
+assert_has_feature(
+    16, 10486, 25326, 'roads',
+    { 'id': 397140734, 'kind': 'major_road', 'sidewalk': 'separate' })

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -310,6 +310,15 @@ filters:
       kind: path
       highway: {col: highway}
       footway: {col: tags->footway}
+  - filter: {highway: corridor}
+    min_zoom: 16
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network_from_tags
+      <<: *osm_footway_properties
+      kind: path
+      highway: corridor
   - filter:
       highway: service
       service: alley

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -49,6 +49,10 @@ global:
       segregated:
         expr: |
           CASE WHEN tags->'segregated' = 'yes' THEN 'yes' END
+      crossing:
+        expr: |
+          CASE WHEN tags->'crossing' <> 'no' THEN tags->'crossing' END
+      sidewalk: {col: tags->sidewalk}
   - &osm_network_from_relation
       network: {expr: "mz_get_rel_network(osm_id)"}
   - &osm_network_from_tags


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/605

The `crossing` and `sidewalk` tags had some varied values, and I opted to just pass those through for now. `crossing` values of `no` are omitted, which seemed like a fair thing to do. `sidewalk`s are always included, whether `no` or `none`, since those might be useful based on the context.

@zerebubuth, @nvkelso could you review please?