### PR TITLE
Add barrier=toll_booth to pois layer

### DIFF
--- a/data/migrations/v1.0.0-point.sql
+++ b/data/migrations/v1.0.0-point.sql
@@ -1,0 +1,6 @@
+UPDATE
+  planet_osm_point
+  SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_point.*)
+  WHERE
+    barrier = 'toll_booth'
+    AND COALESCE(mz_poi_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_pois(planet_osm_point.*), 999);

--- a/data/migrations/v1.0.0-polygon.sql
+++ b/data/migrations/v1.0.0-polygon.sql
@@ -1,0 +1,6 @@
+UPDATE
+  planet_osm_polygon
+  SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(planet_osm_polygon.*)
+  WHERE
+    barrier = 'toll_booth'
+    AND COALESCE(mz_poi_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_pois(planet_osm_polygon.*), 999);

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -771,6 +771,7 @@ Features from OpenStreetMap which are tagged `disused=*` for any other value tha
 * `therapist`
 * `toilets`
 * `toilets`
+* `toll_booth`
 * `townhall`
 * `toys`
 * `trade`

--- a/test/479-barrier-toll_booth.py
+++ b/test/479-barrier-toll_booth.py
@@ -1,0 +1,10 @@
+# http://www.openstreetmap.org/way/25814380
+assert_has_feature(
+    16, 10471, 25323, 'pois',
+    { 'id': 25814380, 'kind': 'toll_booth' })
+
+# Node: Main Gate (392430963)
+# http://www.openstreetmap.org/node/392430963
+assert_has_feature(
+    16, 10473, 25332, 'pois',
+    { 'id': 392430963, 'kind': 'toll_booth' })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -268,6 +268,9 @@ filters:
   - filter: {barrier: gate}
     min_zoom: 15
     output: {kind: gate}
+  - filter: {barrier: toll_booth}
+    min_zoom: 15
+    output: {kind: toll_booth}
   - filter: {craft: sawmill}
     min_zoom: 15
     output: {kind: sawmill}


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/479

The first test, http://www.openstreetmap.org/way/25814380 , also has a `building` tag. It is showing up in the `buildings` layer, and now it will be showing up in the `pois` layer too. It also has a `landuse_kind=park` on it. Is it a problem that it will start showing up in multiple layers?

@nvkelso, @zerebubuth could you review please?