### PR TITLE
Don't drop building features which are also label placements.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -342,7 +342,8 @@ post_process:
       source_layer: landuse
       start_zoom: 6
       where: >-
-        properties.get('mz_is_building') is True
+        properties.get('mz_is_building') is True and
+        properties.get('label_placement') is None
   - fn: TileStache.Goodies.VecTiles.transform.merge_duplicate_stations
     params:
       source_layer: pois


### PR DESCRIPTION
We used to drop the `mz_is_building` property from label placements during the generation process using `drop_keys`, and then remove all features with `mz_is_building` in a later post-process stage. We recently removed `drop_keys` in favour of a more general process to drop all `mz_*` properties, but this meant the second stage was removing the label placements too.

This changes the filter so that anything marked `label_placement` is not removed.

@rmarianski could you review, please?