### PR TITLE
Ignore l10n for non-OSM & non-WOF names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,14 @@ test.log
 
 # editor temporaries
 *~
+
 # downloaded shapefiles
 data/*.shp
 data/*.cpg
 data/*.dbf
 data/*.prj
 data/*.shx
+
+# python compiled bytecode and development files
+*.pyc
+vector_datasource.egg-info/

--- a/integration-test/366-beaches.py
+++ b/integration-test/366-beaches.py
@@ -1,5 +1,5 @@
 # Baker beach, SF
-# https://www.openstreetmap.org/way/195638009
+# https://www.openstreetmap.org/relation/6260732
 assert_has_feature(
     18, 41881, 101308, 'landuse',
     { 'kind': 'beach' })

--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -30,7 +30,7 @@ function cleanup {
    fi
    echo "=== Dropping database \"${dbname}\" and cleaning up..."
    dropdb --if-exists "${dbname}"
-   rm -f empty.osm data.osc
+   rm -f empty.osm data.osc test_server.port
 }
 
 # set the env var $NOCLEANUP to anything and the code won't clean up. this is

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -425,8 +425,6 @@ def tags_name_i18n(shape, properties, fid, zoom):
     is_wof = source == 'whosonfirst.mapzen.com'
     is_osm = source == 'openstreetmap.org'
 
-    alt_name_prefix_candidates = []
-
     if is_osm:
         alt_name_prefix_candidates = [
             'name:left:', 'name:right:', 'name:', 'alt_name:', 'old_name:'
@@ -435,6 +433,11 @@ def tags_name_i18n(shape, properties, fid, zoom):
     elif is_wof:
         alt_name_prefix_candidates = ['name:']
         convert_fn = _convert_wof_l10n_name
+    else:
+        # conversion function only implemented for things which come from OSM
+        # or WOF - implement more cases here when more localized named sources
+        # become available.
+        return shape, properties, fid
 
     for k, v in tags.items():
         if v == name:


### PR DESCRIPTION
We have l10n conversion functions for WOF and OSM, but leave the variable unset when the source doesn't match either of those. Just to be on the safe side, this changes the behaviour to exit the function when the source doesn't match either WOF or OSM.

Also, fixes up a test case which was failing due to a data change.

Also, minor fixes to clean up from the test running script and ignore Python-related development files.

@rmarianski could you review, please?