### PR TITLE
Add support for configurable pixel sizes

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -339,6 +339,80 @@ post_process:
       source_layer: transit
       target_value_type: int
 
+  # add minimum pixel thresholds per layer
+  # this should run after all the `class`es have been assigned to features
+  # these are configured only for layers that contain polygonal
+  # geometries
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/water.csv
+    params:
+      source_layer: water
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/earth.csv
+    params:
+      source_layer: earth
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/landuse.csv
+    params:
+      source_layer: landuse
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/buildings.csv
+    params:
+      source_layer: buildings
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/boundaries.csv
+    params:
+      source_layer: boundaries
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/mz_min_pixels/transit.csv
+    params:
+      source_layer: transit
+      target_value_type: int
+
+  # drop all polygonal features that don't meet the minimum area
+  # threshold. this depends on the mz_min_pixels property to be set on
+  # features first
+  - fn: vectordatasource.transform.drop_features_mz_min_pixels
+    params:
+      property: mz_min_pixels
+      source_layers:
+        # all layers that have polygonal geometries
+        - boundaries
+        - buildings
+        - earth
+        - landuse
+        - transit
+        - water
+
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads

--- a/queries.yaml
+++ b/queries.yaml
@@ -256,6 +256,89 @@ post_process:
       source_layer: water
       target_value_type: int
 
+  # assign `class` to features
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/water.csv
+    params:
+      source_layer: water
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/earth.csv
+    params:
+      source_layer: earth
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/places.csv
+    params:
+      source_layer: places
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/landuse.csv
+    params:
+      source_layer: landuse
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/roads.csv
+    params:
+      source_layer: roads
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/buildings.csv
+    params:
+      source_layer: buildings
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/pois.csv
+    params:
+      source_layer: pois
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/boundaries.csv
+    params:
+      source_layer: boundaries
+      target_value_type: int
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/class/transit.csv
+    params:
+      source_layer: transit
+      target_value_type: int
+
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='vector-datasource',
           'pycountry',
           'simplejson',
           'StreetNames',
+          'tilequeue',
       ],
       test_suite='test',
       tests_require=[

--- a/spreadsheets/class/boundaries.csv
+++ b/spreadsheets/class/boundaries.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/buildings.csv
+++ b/spreadsheets/class/buildings.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/earth.csv
+++ b/spreadsheets/class/earth.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/landuse.csv
+++ b/spreadsheets/class/landuse.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/places.csv
+++ b/spreadsheets/class/places.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/pois.csv
+++ b/spreadsheets/class/pois.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/roads.csv
+++ b/spreadsheets/class/roads.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/transit.csv
+++ b/spreadsheets/class/transit.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/class/water.csv
+++ b/spreadsheets/class/water.csv
@@ -1,0 +1,1 @@
+kind,class

--- a/spreadsheets/mz_min_pixels/boundaries.csv
+++ b/spreadsheets/mz_min_pixels/boundaries.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/spreadsheets/mz_min_pixels/buildings.csv
+++ b/spreadsheets/mz_min_pixels/buildings.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/spreadsheets/mz_min_pixels/earth.csv
+++ b/spreadsheets/mz_min_pixels/earth.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/spreadsheets/mz_min_pixels/landuse.csv
+++ b/spreadsheets/mz_min_pixels/landuse.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/spreadsheets/mz_min_pixels/transit.csv
+++ b/spreadsheets/mz_min_pixels/transit.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/spreadsheets/mz_min_pixels/water.csv
+++ b/spreadsheets/mz_min_pixels/water.csv
@@ -1,0 +1,1 @@
+class::int,mz_min_pixels

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -78,3 +78,60 @@ class TagsNameI18nTest(unittest.TestCase):
                                            'eng_x', 'foo')
         self.assertTrue('name:eng' in props)
         self.assertEquals('foo', props['name:eng'])
+
+
+class DropFeaturesMinPixelsTest(unittest.TestCase):
+
+    def _make_feature_layers(self, pixel_threshold, shape):
+        props = dict(mz_min_pixels=pixel_threshold)
+        fid = None
+        feature = shape, props, fid
+        features = [feature]
+        feature_layers = [dict(name='layer-name', features=features)]
+        return feature_layers
+
+    def _call_fut(self, feature_layers, zoom):
+        from tilequeue.process import Context
+        from ModestMaps.Core import Coordinate
+        from vectordatasource.transform import drop_features_mz_min_pixels
+        params = dict(property='mz_min_pixels', source_layers=('layer-name',))
+        ctx = Context(
+            feature_layers=feature_layers,
+            tile_coord=Coordinate(column=1, row=1, zoom=zoom),
+            params=params,
+            unpadded_bounds=None,
+            padded_bounds=None,
+            resources=None,
+        )
+        result = drop_features_mz_min_pixels(ctx)
+        return result
+
+    def test_feature_drops(self):
+        import shapely.geometry
+        exterior_ring = [
+            (0, 0),
+            (0, 1),
+            (1, 1),
+            (0, 0),
+        ]
+        polygon = shapely.geometry.Polygon(exterior_ring)
+        feature_layers = self._make_feature_layers(1, polygon)
+        zoom = 1
+        self._call_fut(feature_layers, zoom)
+        features = feature_layers[0]['features']
+        self.assertEquals(0, len(features))
+
+    def test_feature_remains(self):
+        import shapely.geometry
+        exterior_ring = [
+            (0, 0),
+            (0, 1),
+            (1, 1),
+            (0, 0),
+        ]
+        polygon = shapely.geometry.Polygon(exterior_ring)
+        feature_layers = self._make_feature_layers(1, polygon)
+        zoom = 20
+        self._call_fut(feature_layers, zoom)
+        features = feature_layers[0]['features']
+        self.assertEquals(1, len(features))


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/810

Included in this pr is a system to assign `class`es to features. Based on earlier conversations, I assume that we want to expose these properties in the tiles themselves. If we don't, we should rename to `mz_class` and they will get dropped. I also just made them integers for now; but they can be changed to whatever is easier to work with. Something else to consider is that the word `class` might not be the smartest choice because it's a keyword in many languages. However, I tried it in a node.js repl and didn't seem to have any problems with it though.

The implementation here re-uses the csv machinery to specify and assign these properties. The idea is that the `mz_min_pixels` spreadsheets will define the rules for the configurable pixel sizes, and a transform is configured that drops any features with areas that don't meet this threshold. The transform assumes that the thresholds will be in pixel values, and calculates the required area for the feature based on the zoom level. Having the capability to assign `class` values could be useful to determine the pixel thresholds.

Note that there aren't any rules specified, but the pieces are in place to honor any subsequent changes.

@zerebubuth, @nvkelso could you review please?