### PR TITLE
Update queries/transforms for new padded bounds

### DIFF
--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -12,7 +12,7 @@ SELECT
 FROM
     ne_110m_admin_0_boundary_lines_land t
 WHERE
-    {{ bounds|bbox_filter('the_geom') }} AND
+    {{ bounds['line']|bbox_filter('the_geom') }} AND
     mz_boundary_min_zoom <= {{ zoom }}
 
 {% elif 2 <= zoom < 5 %}
@@ -22,7 +22,7 @@ SELECT
 FROM
     ne_50m_admin_0_boundary_lines_land t
 WHERE
-    {{ bounds|bbox_filter('the_geom') }} AND
+    {{ bounds['line']|bbox_filter('the_geom') }} AND
     mz_boundary_min_zoom <= {{ zoom }}
 
 UNION ALL
@@ -32,7 +32,7 @@ SELECT
 FROM
     ne_50m_admin_1_states_provinces_lines t
 WHERE
-    {{ bounds|bbox_filter('the_geom') }} AND
+    {{ bounds['line']|bbox_filter('the_geom') }} AND
     mz_boundary_min_zoom <= {{ zoom }}
 
 {% elif 5 <= zoom < 8 %}
@@ -44,7 +44,7 @@ SELECT
 FROM
     ne_10m_admin_0_boundary_lines_land t
 WHERE
-    {{ bounds|bbox_filter('the_geom') }} AND
+    {{ bounds['line']|bbox_filter('the_geom') }} AND
     mz_boundary_min_zoom <= {{ zoom }}
 
 UNION ALL
@@ -56,7 +56,7 @@ SELECT
 FROM
     ne_10m_admin_1_states_provinces_lines t
 WHERE
-    {{ bounds|bbox_filter('the_geom') }} AND
+    {{ bounds['line']|bbox_filter('the_geom') }} AND
     mz_boundary_min_zoom <= {{ zoom }}
 
 {% else %}
@@ -69,14 +69,14 @@ SELECT
   -- then take the boundary, then reverse and intersect with
   -- the query bbox. this is needed because Shapely expects a
   -- correctly-oriented outer to run counter-clockwise.
-  {% filter geometry %}{{ bounds|bbox_intersection('st_reverse(st_boundary(st_forcerhr(way)))') }}{% endfilter %} AS __geometry__,
+  {% filter geometry %}{{ bounds['line']|bbox_intersection('st_reverse(st_boundary(st_forcerhr(way)))') }}{% endfilter %} AS __geometry__,
   osm_id AS __id__,
   %#tags AS tags
 
 FROM planet_osm_polygon
 
 WHERE
-  {{ bounds|bbox_filter('way') }} AND
+  {{ bounds['line']|bbox_filter('way') }} AND
   mz_boundary_min_zoom <= {{ zoom }}
 
 UNION ALL
@@ -85,14 +85,14 @@ SELECT
   NULL AS name,
   true AS maritime_boundary,
   '{"kind": "maritime"}'::json as mz_properties,
-  {% filter geometry %}{{ bounds|bbox_intersection('the_geom') }}{% endfilter %} AS __geometry__,
+  {% filter geometry %}{{ bounds['polygon']|bbox_intersection('the_geom') }}{% endfilter %} AS __geometry__,
   gid AS __id__,
   NULL AS tags
 
 FROM buffered_land
 
 WHERE
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -108,7 +108,7 @@ FROM
   planet_osm_line
 
 WHERE
-  {{ bounds|bbox_filter('way') }} AND
+  {{ bounds['line']|bbox_filter('way') }} AND
   mz_boundary_min_zoom <= {{ zoom }}
 
 {% endif %}

--- a/queries/buildings.jinja2
+++ b/queries/buildings.jinja2
@@ -21,7 +21,7 @@ FROM
 
 WHERE
 
-    {{ bounds|bbox_filter('way') }} AND
+    {{ bounds['polygon']|bbox_filter('way') }} AND
 {% if zoom >= 16 %}
     mz_building_min_zoom IS NOT NULL
 {% else %}
@@ -47,7 +47,7 @@ FROM
 
 WHERE
 
-    {{ bounds|bbox_filter('way') }} AND
+    {{ bounds['point']|bbox_filter('way') }} AND
     mz_building_min_zoom IS NOT NULL
 
 {% endif %}

--- a/queries/earth.jinja2
+++ b/queries/earth.jinja2
@@ -20,7 +20,7 @@ FROM
 
 WHERE
     mz_earth_min_zoom <= {{ zoom }} AND
-    {{ bounds|bbox_filter('the_geom') }}
+    {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 {% else %}
 
@@ -38,7 +38,7 @@ FROM
     land_polygons t
 
 WHERE
-    {{ bounds|bbox_filter('the_geom') }}
+    {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 {% endif %}
 
@@ -64,7 +64,7 @@ WHERE
 {% else %}
     mz_earth_min_zoom IS NOT NULL AND
 {% endif %}
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['polygon']|bbox_filter('way') }}
 
 UNION ALL
 
@@ -86,10 +86,9 @@ WHERE
 {% else %}
     mz_earth_min_zoom IS NOT NULL AND
 {% endif %}
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['line']|bbox_filter('way') }}
 
 {% endif %}
-
 
 UNION ALL
 
@@ -112,4 +111,4 @@ WHERE
 {% else %}
   mz_earth_min_zoom IS NOT NULL AND
 {% endif %}
-  {{ bounds|bbox_filter('way') }}
+  {{ bounds['point']|bbox_filter('way') }}

--- a/queries/landuse.jinja2
+++ b/queries/landuse.jinja2
@@ -8,7 +8,7 @@
     gid AS __id__
 {% endmacro %}
 
-{% macro osm_landuse_detailed_query(table) %}
+{% macro osm_landuse_detailed_query(table, geom_type) %}
 SELECT
 {% if table == 'planet_osm_polygon' %}
     CASE WHEN mz_poi_min_zoom IS NULL THEN name ELSE NULL END AS name,
@@ -34,7 +34,7 @@ SELECT
 FROM
     {{ table }}
 WHERE
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds[geom_type]|bbox_filter('way') }}
     {% if zoom <= 15 %}
     AND mz_landuse_min_zoom <= {{ zoom }}
     {% else %}
@@ -100,17 +100,17 @@ SELECT
 FROM
   planet_osm_polygon
 WHERE
-  {{ bounds|bbox_filter('way') }}
+  {{ bounds['polygon']|bbox_filter('way') }}
   AND (boundary IN ('national_park', 'protected_area') OR leisure='nature_reserve')
   AND mz_landuse_min_zoom <= {{ zoom }}
 
 {% else %}
 
-{{ osm_landuse_detailed_query('planet_osm_polygon') }}
+{{ osm_landuse_detailed_query('planet_osm_polygon', 'polygon') }}
 
 UNION ALL
 
-{{ osm_landuse_detailed_query('planet_osm_line') }}
+{{ osm_landuse_detailed_query('planet_osm_line', 'line') }}
 
 {% if zoom < 10 %}
 UNION ALL
@@ -131,7 +131,7 @@ SELECT
 FROM
   ne_10m_urban_areas
 WHERE
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['polygon']|bbox_filter('the_geom') }}
 {% endif %}
 
 {% endif %}

--- a/queries/places.jinja2
+++ b/queries/places.jinja2
@@ -22,7 +22,7 @@ FROM ne_10m_populated_places
 
 WHERE
     mz_places_min_zoom <= {{ zoom }}
-    AND {{ bounds|bbox_filter('the_geom') }}
+    AND {{ bounds['point']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -50,7 +50,7 @@ FROM planet_osm_point
 
 WHERE
     mz_places_min_zoom <= {{ zoom }}
-    AND {{ bounds|bbox_filter('way') }}
+    AND {{ bounds['point']|bbox_filter('way') }}
 
 {% if zoom >= 11 %}
 UNION ALL
@@ -81,7 +81,7 @@ INNER JOIN wof_neighbourhood_placetype wof_np ON wof_n.placetype = wof_np.placet
 
 WHERE
   wof_n.is_visible AND
-  {{ bounds|bbox_filter('label_position') }} AND
+  {{ bounds['point']|bbox_filter('label_position') }} AND
   {{ zoom + 1 }} >= min_zoom AND
   {{ zoom - 1 }} <= max_zoom
 

--- a/queries/pois.jinja2
+++ b/queries/pois.jinja2
@@ -44,7 +44,7 @@ FROM (
     planet_osm_point
 
   WHERE
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['point']|bbox_filter('way') }}
 {% if zoom >= 16 %}
     AND mz_poi_min_zoom IS NOT NULL
 {% else %}
@@ -75,7 +75,7 @@ UNION ALL
     planet_osm_polygon
 
   WHERE
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['point']|bbox_filter('way') }}
 {% if zoom >= 16 %}
     AND mz_poi_min_zoom IS NOT NULL
 {% else %}

--- a/queries/roads.jinja2
+++ b/queries/roads.jinja2
@@ -8,7 +8,7 @@ SELECT
 FROM ne_10m_roads
 
 WHERE
-    {{ bounds|bbox_filter('the_geom') }}
+    {{ bounds['line']|bbox_filter('the_geom') }}
     AND scalerank <= {{ zoom }}
 
 {% else %}
@@ -36,7 +36,7 @@ SELECT
 FROM planet_osm_line
 
 WHERE
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['line']|bbox_filter('way') }}
     AND mz_road_level <= {{ zoom }}
 
 {% endif %}

--- a/queries/transit.jinja2
+++ b/queries/transit.jinja2
@@ -1,4 +1,4 @@
-{% macro transit_query(table) %}
+{% macro transit_query(table, geom_type) %}
 SELECT
     osm_id AS __id__,
     {% filter geometry %}way{% endfilter %} AS __geometry__,
@@ -24,7 +24,7 @@ SELECT
 FROM {{ table }}
 
 WHERE
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds[geom_type]|bbox_filter('way') }}
 {% if zoom >= 16 %}
     AND mz_transit_level IS NOT NULL
 {% else %}
@@ -32,8 +32,8 @@ WHERE
 {% endif %}
 {% endmacro %}
 
-{{ transit_query('planet_osm_line') }}
+{{ transit_query('planet_osm_line', 'line') }}
 
 UNION ALL
 
-{{ transit_query('planet_osm_polygon') }}
+{{ transit_query('planet_osm_polygon', 'polygon') }}

--- a/queries/water.jinja2
+++ b/queries/water.jinja2
@@ -23,7 +23,7 @@ FROM ne_10m_ocean t
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -41,7 +41,7 @@ FROM ne_10m_lakes t
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -66,7 +66,7 @@ FROM
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['line']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -91,7 +91,7 @@ FROM
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['line']|bbox_filter('the_geom') }}
 
 {% if 4 <= zoom < 9 %}
 UNION ALL
@@ -108,7 +108,7 @@ FROM ne_10m_playas t
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -131,7 +131,7 @@ FROM
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('the_geom') }}
+  {{ bounds['line']|bbox_filter('the_geom') }}
 
 {% endif %}
 
@@ -149,7 +149,7 @@ SELECT
 
 FROM water_polygons t
 
-WHERE {{ bounds|bbox_filter('the_geom') }}
+WHERE {{ bounds['polygon']|bbox_filter('the_geom') }}
 
 UNION ALL
 
@@ -168,7 +168,7 @@ FROM planet_osm_polygon t
 
 WHERE
     mz_water_min_zoom <= {{ zoom }} AND
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['polygon']|bbox_filter('way') }}
 
 UNION ALL
 
@@ -187,7 +187,7 @@ FROM planet_osm_line t
 
 WHERE
     mz_water_min_zoom <= {{ zoom }} AND
-    {{ bounds|bbox_filter('way') }}
+    {{ bounds['line']|bbox_filter('way') }}
 
 {% endif %}
 
@@ -213,4 +213,4 @@ FROM
 
 WHERE
   mz_water_min_zoom <= {{ zoom }} AND
-  {{ bounds|bbox_filter('way') }}
+  {{ bounds['point']|bbox_filter('way') }}

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -101,7 +101,6 @@ class DropFeaturesMinPixelsTest(unittest.TestCase):
             params=params,
             unpadded_bounds=None,
             resources=None,
-            buffer_cfg=None,
         )
         result = drop_features_mz_min_pixels(ctx)
         return result


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/106
Depends on https://github.com/mapzen/tilequeue/pull/97

The padded bounds are now a dict that are keyed off a geometry type:
point, line, polygon. All queries should now use the type specific for
the geometry they are querying for, and transforms/code should use the
bounds appropriate for their type during processing.

@zerebubuth could you review please?